### PR TITLE
add support for `yield` and `yield from`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -255,6 +255,8 @@ export const UNKNOWN = new SourceType('UNKNOWN');
 export const WHEN = new SourceType('WHEN');
 export const WHILE = new SourceType('WHILE');
 export const IDENTIFIER = new SourceType('IDENTIFIER');
+export const YIELD = new SourceType('YIELD');
+export const YIELDFROM = new SourceType('YIELDFROM');
 
 /**
  * Borrowed, with tweaks, from CoffeeScript's lexer.coffee.
@@ -369,6 +371,8 @@ export function stream(source: string, index: number=0): () => SourceLocation {
         case RELATION:
         case LOOP:
         case DO:
+        case YIELD:
+        case YIELDFROM:
         case CONTINUATION:
           if (consume(SPACE_PATTERN)) {
             setType(SPACE);
@@ -458,8 +462,11 @@ export function stream(source: string, index: number=0): () => SourceLocation {
             }
           } else if (consume(IDENTIFIER_PATTERN)) {
             let prev = locations[locations.length - 1];
+            let preprev = locations[locations.length - 2];
             if (prev && (prev.type === DOT || prev.type === PROTO)) {
               setType(IDENTIFIER);
+            } else if (prev && preprev && (preprev.type === YIELD) && (prev.type === SPACE) && consumed() == 'from') {
+              setType(YIELDFROM);
             } else {
               switch (consumed()) {
                 case 'if':
@@ -575,6 +582,10 @@ export function stream(source: string, index: number=0): () => SourceLocation {
                   setType(DO);
                   break;
 
+                case 'yield':
+                  setType(YIELD);
+                  break;
+                
                 default:
                   setType(IDENTIFIER);
               }

--- a/test/test.js
+++ b/test/test.js
@@ -67,6 +67,8 @@ import lex, {
   UNDEFINED,
   WHEN,
   WHILE,
+  YIELD,
+  YIELDFROM,
 } from '../src/index.js';
 
 describe('lex', () => {
@@ -1290,6 +1292,42 @@ describe('stream', () => {
         new SourceLocation(SPACE, 2),
         new SourceLocation(IDENTIFIER, 3),
         new SourceLocation(EOF, 6)
+      ]
+    )
+  );
+
+  it('identifies `yield` as a keyword', () =>
+    checkLocations(
+      stream('yield foo'),
+      [
+        new SourceLocation(YIELD, 0),
+        new SourceLocation(SPACE, 5),
+        new SourceLocation(IDENTIFIER, 6),
+        new SourceLocation(EOF, 9)
+      ]
+    )
+  );
+
+  it('identifies `yield from` as keywords', () =>
+    checkLocations(
+      stream('yield from foo'),
+      [
+        new SourceLocation(YIELD, 0),
+        new SourceLocation(SPACE, 5),
+        new SourceLocation(YIELDFROM, 6),
+        new SourceLocation(SPACE, 10),
+        new SourceLocation(IDENTIFIER, 11),
+        new SourceLocation(EOF, 14)
+      ]
+    )
+  );
+
+  it('identifies `from` as an identifier without yield', () =>
+    checkLocations(
+      stream('from'),
+      [
+        new SourceLocation(IDENTIFIER, 0),
+        new SourceLocation(EOF, 4)
       ]
     )
   );


### PR DESCRIPTION
original coffeescript supports them for creating generator functions