### PR TITLE
add support for `yield` and `yield from` (single-token)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+node_modules

--- a/src/index.js
+++ b/src/index.js
@@ -255,6 +255,8 @@ export const UNKNOWN = new SourceType('UNKNOWN');
 export const WHEN = new SourceType('WHEN');
 export const WHILE = new SourceType('WHILE');
 export const IDENTIFIER = new SourceType('IDENTIFIER');
+export const YIELD = new SourceType('YIELD');
+export const YIELDFROM = new SourceType('YIELDFROM');
 
 /**
  * Borrowed, with tweaks, from CoffeeScript's lexer.coffee.
@@ -273,6 +275,7 @@ const IDENTIFIER_PATTERN = /^(?!\d)((?:(?!\s)[$\w\x7f-\uffff])+)/;
 const NUMBER_PATTERN = /^0b[01]+|^0o[0-7]+|^0x[\da-f]+|^\d*\.?\d+(?:e[+-]?\d+)?/i;
 const SPACE_PATTERN = /^[^\n\r\S]+/;
 const REGEXP_PATTERN = /^\/(?!\/)((?:[^[\/\n\\]|\\[^\n]|\[(?:\\[^\n]|[^\]\n\\])*\])*)(\/)?/;
+const YIELDFROM_PATTERN = /^yield[^\n\r\S]+from/;
 
 const OPERATORS = [
   // equality
@@ -369,6 +372,8 @@ export function stream(source: string, index: number=0): () => SourceLocation {
         case RELATION:
         case LOOP:
         case DO:
+        case YIELD:
+        case YIELDFROM:
         case CONTINUATION:
           if (consume(SPACE_PATTERN)) {
             setType(SPACE);
@@ -456,6 +461,8 @@ export function stream(source: string, index: number=0): () => SourceLocation {
             } else {
               setType(OPERATOR);
             }
+          } else if (consume(YIELDFROM_PATTERN)) {
+            setType(YIELDFROM);
           } else if (consume(IDENTIFIER_PATTERN)) {
             let prev = locations[locations.length - 1];
             if (prev && (prev.type === DOT || prev.type === PROTO)) {
@@ -575,6 +582,10 @@ export function stream(source: string, index: number=0): () => SourceLocation {
                   setType(DO);
                   break;
 
+                case 'yield':
+                  setType(YIELD);
+                  break;
+                
                 default:
                   setType(IDENTIFIER);
               }

--- a/test/test.js
+++ b/test/test.js
@@ -67,6 +67,8 @@ import lex, {
   UNDEFINED,
   WHEN,
   WHILE,
+  YIELD,
+  YIELDFROM,
 } from '../src/index.js';
 
 describe('lex', () => {
@@ -1290,6 +1292,40 @@ describe('stream', () => {
         new SourceLocation(SPACE, 2),
         new SourceLocation(IDENTIFIER, 3),
         new SourceLocation(EOF, 6)
+      ]
+    )
+  );
+
+  it('identifies `yield` as a keyword', () =>
+    checkLocations(
+      stream('yield foo'),
+      [
+        new SourceLocation(YIELD, 0),
+        new SourceLocation(SPACE, 5),
+        new SourceLocation(IDENTIFIER, 6),
+        new SourceLocation(EOF, 9)
+      ]
+    )
+  );
+
+  it('identifies `yield from` as keyword', () =>
+    checkLocations(
+      stream('yield  from foo'),
+      [
+        new SourceLocation(YIELDFROM, 0),
+        new SourceLocation(SPACE, 11),
+        new SourceLocation(IDENTIFIER, 12),
+        new SourceLocation(EOF, 15)
+      ]
+    )
+  );
+
+  it('identifies `from` as an identifier without yield', () =>
+    checkLocations(
+      stream('from'),
+      [
+        new SourceLocation(IDENTIFIER, 0),
+        new SourceLocation(EOF, 4)
       ]
     )
   );


### PR DESCRIPTION
As suggested in #1 with emitting only a single token for `yield from`