### PR TITLE
fix: @on() is a function call not a bool followed by parens

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -434,7 +434,7 @@ export function stream(source: string, index: number=0): () => SourceLocation {
             setType(YIELDFROM);
           } else if (consume(IDENTIFIER_PATTERN)) {
             let prev = locations[locations.length - 1];
-            if (prev && (prev.type === DOT || prev.type === PROTO)) {
+            if (prev && (prev.type === DOT || prev.type === PROTO || prev.type === AT)) {
               setType(IDENTIFIER);
             } else {
               switch (consumed()) {
@@ -554,7 +554,7 @@ export function stream(source: string, index: number=0): () => SourceLocation {
                 case 'yield':
                   setType(YIELD);
                   break;
-                
+
                 default:
                   setType(IDENTIFIER);
               }

--- a/test/test.js
+++ b/test/test.js
@@ -312,6 +312,19 @@ describe('lex', () => {
       ]
     )
   );
+
+  it('@on() is a function call not and not a bool followed by parens', () =>
+    deepEqual(
+      lex(`@on()`).toArray(),
+      [
+        new SourceToken(AT, 0, 1),
+        new SourceToken(IDENTIFIER, 1, 3),
+        new SourceToken(CALL_START, 3, 4),
+        new SourceToken(CALL_END, 4, 5),
+        ]
+    )
+  );
+
 });
 
 describe('SourceTokenList', () => {


### PR DESCRIPTION
Discovered when using decaffeinate to translate a class that extended event emitter. 

Example problems:
```
@on('EVENT', handle_fn)
this.on('EVENT', handle_fn));
```

Or

```
@on('EVENT')
this.on(('EVENT'));