### PR TITLE
fix: properly handle double-quoted strings within string interpolations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ function stringLocationsFromStream(stream: BufferedStream): Array<SourceLocation
         loc.type,
         loc.index
       ));
-    } else if (loc.type === first.type) {
+    } else if (!insideInterpolation && loc.type === first.type) {
       let next = stream.peek();
       if (next.type === INTERPOLATION_START) {
         // "abc#{def}ghi#{jkl}mno"

--- a/test/test.js
+++ b/test/test.js
@@ -478,6 +478,31 @@ describe('SourceTokenList', () => {
     strictEqual(range && range[1], expectedEnd);
   });
 
+  it('can determine the interpolated string range with an interior string', () => {
+    let list = lex('"#{"a"}"');
+
+    deepEqual(
+      list.map(t => t.type),
+      [
+        STRING_START,
+        STRING_CONTENT,
+        INTERPOLATION_START,
+        DSTRING,
+        INTERPOLATION_END,
+        STRING_CONTENT,
+        STRING_END,
+      ]
+    );
+
+    // Go past STRING_START & STRING_CONTENT.
+    let interpolationStart = list.startIndex.advance(2);
+    let range = list.rangeOfInterpolatedStringTokensContainingTokenIndex(
+      interpolationStart
+    );
+    strictEqual(range[0], list.startIndex);
+    strictEqual(range[1], list.endIndex);
+  });
+
   it('allows comparing indexes', () => {
     let list = lex('a b');
     let { startIndex, endIndex } = list;


### PR DESCRIPTION
Closes https://github.com/decaffeinate/decaffeinate-parser/issues/14.
Closes https://github.com/decaffeinate/decaffeinate/issues/229.
Closes https://github.com/decaffeinate/decaffeinate/issues/435.

The code that builds interpolation tokens had a case where it handled
intermediate string fragments in the template string, but sometimes it would
falsely identify a double-quoted string inside an interpolation as one of these
string fragments. Fortunately, we already track a boolean for whether we're
inside an interpolation or not, so we can just add that boolean to the check.

This issue ended up causing the range of the string template to be interpreted
incorrectly (the end would be too soon), which caused an infinite loop in
decaffeinate-parser when it searched backward from the end until the first '}'
character.

In addition to running the coffee-lex tests, I also ran the decaffeinate-parser
and decaffeinate tests with this patch applied and they all pass.