### PR TITLE
fix: allow newlines when looking for identifiers after DOT tokens

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -435,7 +435,11 @@ export function stream(source: string, index: number=0): () => SourceLocation {
           } else if (consume(YIELDFROM_PATTERN)) {
             setType(YIELDFROM);
           } else if (consume(IDENTIFIER_PATTERN)) {
-            let prev = locations[locations.length - 1];
+            let prevLocationIndex = locations.length - 1;
+            while (prevLocationIndex > 0 && locations[prevLocationIndex].type === NEWLINE) {
+              prevLocationIndex--;
+            }
+            let prev = locations[prevLocationIndex];
             if (prev && (prev.type === DOT || prev.type === PROTO || prev.type === AT)) {
               setType(IDENTIFIER);
             } else {

--- a/test/test.js
+++ b/test/test.js
@@ -1077,6 +1077,23 @@ describe('stream', () => {
     )
   );
 
+  it('identifies identifiers with keyword names after dot access after a newline', () =>
+    checkLocations(
+      stream(`s.
+else(0)`),
+      [
+        new SourceLocation(IDENTIFIER, 0),
+        new SourceLocation(DOT, 1),
+        new SourceLocation(NEWLINE, 2),
+        new SourceLocation(IDENTIFIER, 3),
+        new SourceLocation(CALL_START, 7),
+        new SourceLocation(NUMBER, 8),
+        new SourceLocation(CALL_END, 9),
+        new SourceLocation(EOF, 10)
+      ]
+    )
+  );
+
   it('identifies identifiers with keyword names after proto access', () =>
     checkLocations(
       stream(`s::delete`),


### PR DESCRIPTION
Closes https://github.com/decaffeinate/decaffeinate/issues/437.

If we see a DOT token, then the next token shouldn't be treated as a keyword
because it should instead be seen as a property access. This was already handled
in the code, but it's even true when there's a newline in between the dot and
the keyword. So, when computing the previous token, we want to skip any NEWLINE
tokens we see, and check if the next earlier one is a DOT (or PROTO or AT).