### PR TITLE
fix: avoid infinite loop on incomplete interpolated triple-quoted strings

### DIFF
--- a/src/utils/tripleQuotedStringSourceLocations.js
+++ b/src/utils/tripleQuotedStringSourceLocations.js
@@ -3,7 +3,7 @@
 import IndexRangeList from './IndexRangeList.js';
 import SourceLocation from '../SourceLocation.js';
 import type BufferedStream from './BufferedStream.js';
-import { INTERPOLATION_START, INTERPOLATION_END, SPACE, STRING_START, STRING_CONTENT, STRING_END, TDSTRING, TSSTRING } from '../index.js';
+import { EOF, INTERPOLATION_START, INTERPOLATION_END, SPACE, STRING_START, STRING_CONTENT, STRING_END, TDSTRING, TSSTRING } from '../index.js';
 
 const QUOTE_LENGTH = 3;
 
@@ -152,8 +152,13 @@ function forEachLocationWithInterpolationDepth(next: () => ?SourceLocation, iter
   for (;;) {
     let location = next();
 
+    // The stream gives a null location to indicate successful completion.
     if (!location) {
       break;
+    }
+
+    if (location.type === EOF) {
+      throw new Error('Reached end of file before finding end of triple-quoted string interpolation.');
     }
 
     iterator(location, interpolationDepth, previous);

--- a/test/test.js
+++ b/test/test.js
@@ -1423,6 +1423,14 @@ else(0)`),
     }
   });
 
+  it('does not infinite loop on incomplete triple-quoted string interpolations', () => {
+    try {
+      lex('a = """#{');
+    } catch (e) {
+      ok(e.message.indexOf('Reached end of file') > -1);
+    }
+  });
+
   function checkLocations(stream: () => SourceLocation, expectedLocations: Array<SourceLocation>) {
     let actualLocations = consumeStream(stream);
     deepEqual(actualLocations, expectedLocations);


### PR DESCRIPTION
This is similar to #54, but triple-quoted strings end up using a different code
path, so we need to handle those as well.