### PR TITLE
refactor: remove code handling \r characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ This function not only lets you control how far into the source you'd like to
 go, it also gives you information about source code that wouldn't become part of
 a token, such as spaces.
 
+Note that the input source code should have only UNIX line endings (LF). If you
+want to process a file with Windows line endings (CRLF), you should convert to
+UNIX line endings first, then use coffee-lex, then convert back if necessary.
+
 ## Why?
 
 The official CoffeeScript lexer does a lot of pre-processing, even with

--- a/src/index.js
+++ b/src/index.js
@@ -266,7 +266,7 @@ export function stream(source: string, index: number=0): () => SourceLocation {
         case CONTINUATION:
           if (consume(SPACE_PATTERN)) {
             setType(SPACE);
-          } else if (consumeNewline()) {
+          } else if (consume('\n')) {
             setType(NEWLINE);
           } else if (consume('...') || consume('..')) {
             setType(RANGE);
@@ -515,7 +515,7 @@ export function stream(source: string, index: number=0): () => SourceLocation {
           break;
 
         case COMMENT:
-          if (consumeNewline()) {
+          if (consume('\n')) {
             setType(NEWLINE);
           } else {
             index++;
@@ -624,10 +624,6 @@ export function stream(source: string, index: number=0): () => SourceLocation {
     } else {
       return false;
     }
-  }
-
-  function consumeNewline(): boolean {
-    return consumeAny(['\n', '\r\n', '\r']);
   }
 
   function consumeRegexp(): boolean {

--- a/src/utils/tripleQuotedStringSourceLocations.js
+++ b/src/utils/tripleQuotedStringSourceLocations.js
@@ -198,14 +198,6 @@ function getLeadingMarginEnd(source: string, marginStart: number): number {
     } else if (char === '\n') {
       // End of the margin.
       return i + '\n'.length;
-    } else if (char === '\r') {
-      if (source.charAt(i + '\r'.length) === '\n') {
-        // Ends with \r\n.
-        return i + '\r\n'.length;
-      } else {
-        // Only ends with \r.
-        return i + '\r'.length;
-      }
     } else {
       // Non-space before a newline, so there is no margin.
       return marginStart;
@@ -222,15 +214,6 @@ function getTrailingMarginStart(source: string, marginEnd: number): number {
     if (char === ' ' || char === '\t') {
       // Just part of the margin.
     } else if (char === '\n') {
-      if (source.charAt(i - '\n'.length) === '\r') {
-        // Starts with \r\n.
-        return i - '\r'.length;
-      } else {
-        // Only ends with \n.
-        return i;
-      }
-    } else if (char === '\r') {
-      // Start of the margin.
       return i;
     } else {
       // Non-space before the ending, so there is no margin.
@@ -250,7 +233,7 @@ function getIndentInfoForRanges(source: string, ranges: IndexRangeList): { share
     for (let i = start; i < end; i++) {
       let char = source[i];
 
-      if (char === '\n' || char === '\r') {
+      if (char === '\n') {
         isAtStartOfLine = true;
       } else if (isAtStartOfLine) {
         isAtStartOfLine = false;

--- a/test/test.js
+++ b/test/test.js
@@ -751,30 +751,6 @@ describe('stream', () => {
     )
   );
 
-  it('identifies CRLF as a newline', () =>
-    checkLocations(
-      stream(`a\r\nb`),
-      [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(NEWLINE, 1),
-        new SourceLocation(IDENTIFIER, 3),
-        new SourceLocation(EOF, 4)
-      ]
-    )
-  );
-
-  it('identifies CR as a newline', () =>
-    checkLocations(
-      stream(`a\rb`),
-      [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(NEWLINE, 1),
-        new SourceLocation(IDENTIFIER, 2),
-        new SourceLocation(EOF, 3)
-      ]
-    )
-  );
-
   it('identifies @', () =>
     checkLocations(
       stream(`@a`),


### PR DESCRIPTION
Progress toward https://github.com/decaffeinate/decaffeinate/issues/557

Now that https://github.com/decaffeinate/decaffeinate/pull/553 has landed, we
can assume that any code passed through decaffeinate only has LF line endings,
which simplifies some code, particularly when dealing with triple-quoted
strings.