### PR TITLE
refactor: change herestrings to share initial lexing code with normal strings

### DIFF
--- a/src/SourceTokenList.js
+++ b/src/SourceTokenList.js
@@ -3,7 +3,7 @@
 import SourceToken from './SourceToken.js';
 import SourceTokenListIndex from './SourceTokenListIndex.js';
 import SourceType from './SourceType.js';
-import { STRING_END, STRING_START } from './index.js';
+import { DSTRING_START, DSTRING_END, TDSTRING_START, TDSTRING_END } from './index.js';
 
 type SourceTokenListIndexRange = [SourceTokenListIndex, SourceTokenListIndex];
 
@@ -82,11 +82,20 @@ export default class SourceTokenList {
    * the case of nesting.
    */
   rangeOfInterpolatedStringTokensContainingTokenIndex(index: SourceTokenListIndex): ?SourceTokenListIndexRange {
-    return this.rangeOfMatchingTokensContainingTokenIndex(
-      STRING_START,
-      STRING_END,
-      index
-    );
+    let bestRange = null;
+    for (let [startType, endType] of [[DSTRING_START, DSTRING_END], [TDSTRING_START, TDSTRING_END]]) {
+      let range = this.rangeOfMatchingTokensContainingTokenIndex(
+        startType,
+        endType,
+        index
+      );
+      if (bestRange === null || bestRange === undefined ||
+          (range !== null && range !== undefined &&
+            range[0].distance(range[1]) < bestRange[0].distance(bestRange[1]))) {
+        bestRange = range;
+      }
+    }
+    return bestRange;
   }
 
   /**

--- a/src/SourceTokenListIndex.js
+++ b/src/SourceTokenListIndex.js
@@ -59,6 +59,15 @@ export default class SourceTokenListIndex {
    * if this is less than `other`, and a positive number otherwise.
    */
   compare(other: SourceTokenListIndex): number {
+    return this.distance(other);
+  }
+
+  /**
+   * Returns an int of the relative distance between this index and the other
+   * index (positive if the other one is later, negative if the other one is
+   * earlier).
+   */
+  distance(other: SourceTokenListIndex): number {
     if (other._sourceTokenList !== this._sourceTokenList) {
       throw new Error('cannot compare indexes from different lists');
     }

--- a/src/coffee-lex.js.flow
+++ b/src/coffee-lex.js.flow
@@ -23,6 +23,7 @@ declare class SourceTokenListIndex {
   isBefore(other: SourceTokenListIndex): boolean;
   isAfter(other: SourceTokenListIndex): boolean;
   compare(other: SourceTokenListIndex): number;
+  distance(other: SourceTokenListIndex): number;
 }
 
 declare class SourceTokenList {
@@ -70,6 +71,8 @@ declare var CONTINUE: SourceType;
 declare var DELETE: SourceType;
 declare var DO: SourceType;
 declare var DOT: SourceType;
+declare var DSTRING_END: SourceType;
+declare var DSTRING_START: SourceType;
 declare var ELSE: SourceType;
 declare var EOF: SourceType;
 declare var EXISTENCE: SourceType;
@@ -104,14 +107,16 @@ declare var SEMICOLON: SourceType;
 declare var SPACE: SourceType;
 declare var SUPER: SourceType;
 declare var SWITCH: SourceType;
-declare var TDSTRING: SourceType;
+declare var SSTRING_END: SourceType;
+declare var SSTRING_START: SourceType;
 declare var STRING_CONTENT: SourceType;
-declare var STRING_END: SourceType;
-declare var STRING_START: SourceType;
+declare var TDSTRING_END: SourceType;
+declare var TDSTRING_START: SourceType;
 declare var THEN: SourceType;
 declare var THIS: SourceType;
 declare var TRY: SourceType;
-declare var TSSTRING: SourceType;
+declare var TSSTRING_END: SourceType;
+declare var TSSTRING_START: SourceType;
 declare var UNDEFINED: SourceType;
 declare var UNKNOWN: SourceType;
 declare var WHEN: SourceType;
@@ -144,6 +149,8 @@ export {
   DELETE,
   DO,
   DOT,
+  DSTRING_END,
+  DSTRING_START,
   ELSE,
   EOF,
   EXISTENCE,
@@ -178,14 +185,16 @@ export {
   SPACE,
   SUPER,
   SWITCH,
-  TDSTRING,
+  SSTRING_END,
+  SSTRING_START,
   STRING_CONTENT,
-  STRING_END,
-  STRING_START,
+  TDSTRING_END,
+  TDSTRING_START,
+  TSSTRING_END,
+  TSSTRING_START,
   THEN,
   THIS,
   TRY,
-  TSSTRING,
   UNDEFINED,
   UNKNOWN,
   WHEN,

--- a/test/test.js
+++ b/test/test.js
@@ -21,7 +21,8 @@ import lex, {
   DELETE,
   DO,
   DOT,
-  DSTRING,
+  DSTRING_END,
+  DSTRING_START,
   ELSE,
   EOF,
   EXISTENCE,
@@ -55,14 +56,16 @@ import lex, {
   SPACE,
   SUPER,
   SWITCH,
-  TDSTRING,
+  TDSTRING_END,
+  TDSTRING_START,
   STRING_CONTENT,
-  STRING_END,
-  STRING_START,
+  SSTRING_END,
+  SSTRING_START,
   THEN,
   THIS,
   TRY,
-  TSSTRING,
+  TSSTRING_END,
+  TSSTRING_START,
   UNDEFINED,
   WHEN,
   WHILE,
@@ -94,7 +97,7 @@ describe('lex', () => {
     deepEqual(
       lex(`"b#{c}d#{e}f"`).toArray(),
       [
-        new SourceToken(STRING_START, 0, 1),
+        new SourceToken(DSTRING_START, 0, 1),
         new SourceToken(STRING_CONTENT, 1, 2),
         new SourceToken(INTERPOLATION_START, 2, 4),
         new SourceToken(IDENTIFIER, 4, 5),
@@ -104,7 +107,7 @@ describe('lex', () => {
         new SourceToken(IDENTIFIER, 9, 10),
         new SourceToken(INTERPOLATION_END, 10, 11),
         new SourceToken(STRING_CONTENT, 11, 12),
-        new SourceToken(STRING_END, 12, 13)
+        new SourceToken(DSTRING_END, 12, 13)
       ]
     )
   );
@@ -113,7 +116,7 @@ describe('lex', () => {
     deepEqual(
       lex(`"#{a}#{b}"`).toArray(),
       [
-        new SourceToken(STRING_START, 0, 1),
+        new SourceToken(DSTRING_START, 0, 1),
         new SourceToken(STRING_CONTENT, 1, 1),
         new SourceToken(INTERPOLATION_START, 1, 3),
         new SourceToken(IDENTIFIER, 3, 4),
@@ -123,7 +126,7 @@ describe('lex', () => {
         new SourceToken(IDENTIFIER, 7, 8),
         new SourceToken(INTERPOLATION_END, 8, 9),
         new SourceToken(STRING_CONTENT, 9, 9),
-        new SourceToken(STRING_END, 9, 10)
+        new SourceToken(DSTRING_END, 9, 10)
       ]
     )
   );
@@ -132,7 +135,7 @@ describe('lex', () => {
     deepEqual(
       lex(`"""\n  b#{c}\n  d#{e}f\n"""`).toArray(),
       [
-        new SourceToken(STRING_START, 0, 3),
+        new SourceToken(TDSTRING_START, 0, 3),
         new SourceToken(STRING_CONTENT, 6, 7),
         new SourceToken(INTERPOLATION_START, 7, 9),
         new SourceToken(IDENTIFIER, 9, 10),
@@ -143,7 +146,7 @@ describe('lex', () => {
         new SourceToken(IDENTIFIER, 17, 18),
         new SourceToken(INTERPOLATION_END, 18, 19),
         new SourceToken(STRING_CONTENT, 19, 20),
-        new SourceToken(STRING_END, 21, 24)
+        new SourceToken(TDSTRING_END, 21, 24)
       ]
     )
   );
@@ -152,13 +155,13 @@ describe('lex', () => {
     deepEqual(
       lex(`"""\n#{a}\n"""`).toArray(),
       [
-        new SourceToken(STRING_START, 0, 3),
+        new SourceToken(TDSTRING_START, 0, 3),
         new SourceToken(STRING_CONTENT, 4, 4),
         new SourceToken(INTERPOLATION_START, 4, 6),
         new SourceToken(IDENTIFIER, 6, 7),
         new SourceToken(INTERPOLATION_END, 7, 8),
         new SourceToken(STRING_CONTENT, 8, 8),
-        new SourceToken(STRING_END, 9, 12)
+        new SourceToken(TDSTRING_END, 9, 12)
       ]
     )
   );
@@ -167,19 +170,19 @@ describe('lex', () => {
     deepEqual(
       lex(`"#{"#{a}"}"`).toArray(),
       [
-        new SourceToken(STRING_START, 0, 1),
+        new SourceToken(DSTRING_START, 0, 1),
         new SourceToken(STRING_CONTENT, 1, 1),
         new SourceToken(INTERPOLATION_START, 1, 3),
-        new SourceToken(STRING_START, 3, 4),
+        new SourceToken(DSTRING_START, 3, 4),
         new SourceToken(STRING_CONTENT, 4, 4),
         new SourceToken(INTERPOLATION_START, 4, 6),
         new SourceToken(IDENTIFIER, 6, 7),
         new SourceToken(INTERPOLATION_END, 7, 8),
         new SourceToken(STRING_CONTENT, 8, 8),
-        new SourceToken(STRING_END, 8, 9),
+        new SourceToken(DSTRING_END, 8, 9),
         new SourceToken(INTERPOLATION_END, 9, 10),
         new SourceToken(STRING_CONTENT, 10, 10),
-        new SourceToken(STRING_END, 10, 11)
+        new SourceToken(DSTRING_END, 10, 11)
       ]
     )
   );
@@ -188,13 +191,13 @@ describe('lex', () => {
     deepEqual(
       lex(`"#{ a }"`).toArray(),
       [
-        new SourceToken(STRING_START, 0, 1),
+        new SourceToken(DSTRING_START, 0, 1),
         new SourceToken(STRING_CONTENT, 1, 1),
         new SourceToken(INTERPOLATION_START, 1, 3),
         new SourceToken(IDENTIFIER, 4, 5),
         new SourceToken(INTERPOLATION_END, 6, 7),
         new SourceToken(STRING_CONTENT, 7, 7),
-        new SourceToken(STRING_END, 7, 8)
+        new SourceToken(DSTRING_END, 7, 8)
       ]
     )
   );
@@ -286,13 +289,13 @@ describe('lex', () => {
         new SourceToken(LBRACE, 0, 1),
         new SourceToken(IDENTIFIER, 2, 4),
         new SourceToken(COLON, 4, 5),
-        new SourceToken(STRING_START, 6, 7),
+        new SourceToken(DSTRING_START, 6, 7),
         new SourceToken(STRING_CONTENT, 7, 7),
         new SourceToken(INTERPOLATION_START, 7, 9),
         new SourceToken(IDENTIFIER, 9, 10),
         new SourceToken(INTERPOLATION_END, 10, 11),
         new SourceToken(STRING_CONTENT, 11, 11),
-        new SourceToken(STRING_END, 11, 12),
+        new SourceToken(DSTRING_END, 11, 12),
         new SourceToken(RBRACE, 13, 14)
       ]
     )
@@ -304,10 +307,10 @@ describe('lex', () => {
       [
         new SourceToken(IDENTIFIER, 0, 3),
         new SourceToken(OPERATOR, 4, 5),
-        new SourceToken(STRING_START, 6, 9),
+        new SourceToken(TSSTRING_START, 6, 9),
         new SourceToken(STRING_CONTENT, 16, 21),
         new SourceToken(STRING_CONTENT, 27, 30),
-        new SourceToken(STRING_END, 37, 40)
+        new SourceToken(TSSTRING_END, 37, 40)
       ]
     )
   );
@@ -460,7 +463,7 @@ describe('SourceTokenList', () => {
     let expectedStart = list.startIndex;
     let expectedEnd = list.endIndex;
 
-    // Go past STRING_START & STRING_CONTENT.
+    // Go past DSTRING_START & STRING_CONTENT.
     let interpolationStart = list.startIndex.advance(2);
     let interpolationStartToken = list.tokenAtIndex(interpolationStart);
     strictEqual(
@@ -483,19 +486,19 @@ describe('SourceTokenList', () => {
     deepEqual(
       list.map(t => t.type),
       [
-        STRING_START,
+        DSTRING_START,
         STRING_CONTENT,
         INTERPOLATION_START,
-        STRING_START,
+        DSTRING_START,
         STRING_CONTENT,
-        STRING_END,
+        DSTRING_END,
         INTERPOLATION_END,
         STRING_CONTENT,
-        STRING_END,
+        DSTRING_END,
       ]
     );
 
-    // Go past STRING_START & STRING_CONTENT.
+    // Go past DSTRING_START & STRING_CONTENT.
     let interpolationStart = list.startIndex.advance(2);
     let range = list.rangeOfInterpolatedStringTokensContainingTokenIndex(
       interpolationStart
@@ -559,9 +562,9 @@ describe('stream', () => {
     checkLocations(
       stream(`'abc'`),
       [
-        new SourceLocation(STRING_START, 0),
+        new SourceLocation(SSTRING_START, 0),
         new SourceLocation(STRING_CONTENT, 1),
-        new SourceLocation(STRING_END, 4),
+        new SourceLocation(SSTRING_END, 4),
         new SourceLocation(EOF, 5)
       ]
     )
@@ -571,9 +574,9 @@ describe('stream', () => {
     checkLocations(
       stream(`"abc"`),
       [
-        new SourceLocation(STRING_START, 0),
+        new SourceLocation(DSTRING_START, 0),
         new SourceLocation(STRING_CONTENT, 1),
-        new SourceLocation(STRING_END, 4),
+        new SourceLocation(DSTRING_END, 4),
         new SourceLocation(EOF, 5)
       ]
     )
@@ -583,7 +586,9 @@ describe('stream', () => {
     checkLocations(
       stream(`'''abc'''`),
       [
-        new SourceLocation(TSSTRING, 0),
+        new SourceLocation(TSSTRING_START, 0),
+        new SourceLocation(STRING_CONTENT, 3),
+        new SourceLocation(TSSTRING_END, 6),
         new SourceLocation(EOF, 9)
       ]
     )
@@ -593,7 +598,9 @@ describe('stream', () => {
     checkLocations(
       stream(`"""abc"""`),
       [
-        new SourceLocation(TDSTRING, 0),
+        new SourceLocation(TDSTRING_START, 0),
+        new SourceLocation(STRING_CONTENT, 3),
+        new SourceLocation(TDSTRING_END, 6),
         new SourceLocation(EOF, 9)
       ]
     )
@@ -625,13 +632,13 @@ describe('stream', () => {
     checkLocations(
       stream(`"a#{b}c"`),
       [
-        new SourceLocation(STRING_START, 0),
+        new SourceLocation(DSTRING_START, 0),
         new SourceLocation(STRING_CONTENT, 1),
         new SourceLocation(INTERPOLATION_START, 2),
         new SourceLocation(IDENTIFIER, 4),
         new SourceLocation(INTERPOLATION_END, 5),
         new SourceLocation(STRING_CONTENT, 6),
-        new SourceLocation(STRING_END, 7),
+        new SourceLocation(DSTRING_END, 7),
         new SourceLocation(EOF, 8)
       ]
     )
@@ -641,18 +648,18 @@ describe('stream', () => {
     checkLocations(
       stream(`"#{"#{}"}"`),
       [
-        new SourceLocation(STRING_START, 0),
+        new SourceLocation(DSTRING_START, 0),
         new SourceLocation(STRING_CONTENT, 1),
         new SourceLocation(INTERPOLATION_START, 1),
-        new SourceLocation(STRING_START, 3),
+        new SourceLocation(DSTRING_START, 3),
         new SourceLocation(STRING_CONTENT, 4),
         new SourceLocation(INTERPOLATION_START, 4),
         new SourceLocation(INTERPOLATION_END, 6),
         new SourceLocation(STRING_CONTENT, 7),
-        new SourceLocation(STRING_END, 7),
+        new SourceLocation(DSTRING_END, 7),
         new SourceLocation(INTERPOLATION_END, 8),
         new SourceLocation(STRING_CONTENT, 9),
-        new SourceLocation(STRING_END, 9),
+        new SourceLocation(DSTRING_END, 9),
         new SourceLocation(EOF, 10)
       ]
     )
@@ -705,9 +712,9 @@ describe('stream', () => {
         new SourceLocation(IDENTIFIER, 2),
         new SourceLocation(COLON, 3),
         new SourceLocation(SPACE, 4),
-        new SourceLocation(STRING_START, 5),
+        new SourceLocation(SSTRING_START, 5),
         new SourceLocation(STRING_CONTENT, 6),
-        new SourceLocation(STRING_END, 8),
+        new SourceLocation(SSTRING_END, 8),
         new SourceLocation(SPACE, 9),
         new SourceLocation(RBRACE, 10),
         new SourceLocation(EOF, 11)
@@ -729,9 +736,9 @@ describe('stream', () => {
         new SourceLocation(SPACE, 7),
         new SourceLocation(IDENTIFIER, 8),
         new SourceLocation(LBRACKET, 9),
-        new SourceLocation(STRING_START, 10),
+        new SourceLocation(SSTRING_START, 10),
         new SourceLocation(STRING_CONTENT, 11),
-        new SourceLocation(STRING_END, 14),
+        new SourceLocation(SSTRING_END, 14),
         new SourceLocation(RBRACKET, 15),
         new SourceLocation(SPACE, 16),
         new SourceLocation(RBRACKET, 17),
@@ -928,9 +935,9 @@ describe('stream', () => {
         new SourceLocation(DOT, 5),
         new SourceLocation(IDENTIFIER, 6),
         new SourceLocation(SPACE, 10),
-        new SourceLocation(STRING_START, 11),
+        new SourceLocation(SSTRING_START, 11),
         new SourceLocation(STRING_CONTENT, 12),
-        new SourceLocation(STRING_END, 15),
+        new SourceLocation(SSTRING_END, 15),
         new SourceLocation(EOF, 16)
       ]
     )
@@ -1422,7 +1429,7 @@ else(0)`),
       lex('a = """#{');
       throw new Error('Expected an exception to be thrown.');
     } catch (e) {
-      ok(e.message.indexOf('Reached end of file') > -1);
+      ok(e.message.indexOf('unexpected EOF while parsing a string') > -1);
     }
   });
 

--- a/test/utils/tripleQuotedStringSourceLocations_test.js
+++ b/test/utils/tripleQuotedStringSourceLocations_test.js
@@ -1,18 +1,29 @@
 import BufferedStream from '../../src/utils/BufferedStream.js';
 import SourceLocation from '../../src/SourceLocation.js';
-import getTripleQuotedStringSemanticRanges from '../../src/utils/tripleQuotedStringSourceLocations.js';
-import { IDENTIFIER, INTERPOLATION_START, INTERPOLATION_END, SPACE, STRING_START, STRING_CONTENT, STRING_END, stream } from '../../src/index.js';
+import getTripleQuotedStringSourceLocations from '../../src/utils/tripleQuotedStringSourceLocations.js';
+import {
+  IDENTIFIER,
+  INTERPOLATION_START,
+  INTERPOLATION_END,
+  SPACE,
+  STRING_CONTENT,
+  TDSTRING_START,
+  TDSTRING_END,
+  TSSTRING_START,
+  TSSTRING_END,
+  stream
+} from '../../src/index.js';
 import { deepEqual } from 'assert';
 
 describe('tripleQuotedStringSourceLocations', () => {
   it('returns an array with an empty string content for an empty triple-quoted string', () => {
     let source = `''''''`;
     deepEqual(
-      getTripleQuotedStringSemanticRanges(source, bufferedStream(source)),
+      getTripleQuotedStringSourceLocations(source, bufferedStream(source)),
       [
-        new SourceLocation(STRING_START, 0),
+        new SourceLocation(TSSTRING_START, 0),
         new SourceLocation(STRING_CONTENT, 3),
-        new SourceLocation(STRING_END, 3)
+        new SourceLocation(TSSTRING_END, 3)
       ]
     )
   });
@@ -20,13 +31,13 @@ describe('tripleQuotedStringSourceLocations', () => {
   it('returns an array with SPACE for the leading and trailing newline', () => {
     let source = `'''\na\n'''`;
     deepEqual(
-      getTripleQuotedStringSemanticRanges(source, bufferedStream(source)),
+      getTripleQuotedStringSourceLocations(source, bufferedStream(source)),
       [
-        new SourceLocation(STRING_START, 0),
+        new SourceLocation(TSSTRING_START, 0),
         new SourceLocation(SPACE, 3),
         new SourceLocation(STRING_CONTENT, 4),
         new SourceLocation(SPACE, 5),
-        new SourceLocation(STRING_END, 6)
+        new SourceLocation(TSSTRING_END, 6)
       ]
     )
   });
@@ -34,15 +45,15 @@ describe('tripleQuotedStringSourceLocations', () => {
   it('returns an array with SPACE for shared indents in triple-single-quoted strings', () => {
     let source = `'''\n      abc\n\n      def\n      '''`;
     deepEqual(
-      getTripleQuotedStringSemanticRanges(source, bufferedStream(source)),
+      getTripleQuotedStringSourceLocations(source, bufferedStream(source)),
       [
-        new SourceLocation(STRING_START, 0),
+        new SourceLocation(TSSTRING_START, 0),
         new SourceLocation(SPACE, 3),
         new SourceLocation(STRING_CONTENT, 10),
         new SourceLocation(SPACE, 15),
         new SourceLocation(STRING_CONTENT, 21),
         new SourceLocation(SPACE, 24),
-        new SourceLocation(STRING_END, 31)
+        new SourceLocation(TSSTRING_END, 31)
       ]
     )
   });
@@ -50,15 +61,15 @@ describe('tripleQuotedStringSourceLocations', () => {
   it('returns an array with SPACE for shared indents in triple-double-quoted strings', () => {
     let source = `"""\n      abc\n\n      def\n      """`;
     deepEqual(
-      getTripleQuotedStringSemanticRanges(source, bufferedStream(source)),
+      getTripleQuotedStringSourceLocations(source, bufferedStream(source)),
       [
-        new SourceLocation(STRING_START, 0),
+        new SourceLocation(TDSTRING_START, 0),
         new SourceLocation(SPACE, 3),
         new SourceLocation(STRING_CONTENT, 10),
         new SourceLocation(SPACE, 15),
         new SourceLocation(STRING_CONTENT, 21),
         new SourceLocation(SPACE, 24),
-        new SourceLocation(STRING_END, 31)
+        new SourceLocation(TDSTRING_END, 31)
       ]
     )
   });
@@ -66,9 +77,9 @@ describe('tripleQuotedStringSourceLocations', () => {
   it('returns an array with SPACE for shared indents in interpolated strings', () => {
     let source = `"""\n      a#{b}c\n\n      d#{e}f\n      """`;
     deepEqual(
-      getTripleQuotedStringSemanticRanges(source, bufferedStream(source)),
+      getTripleQuotedStringSourceLocations(source, bufferedStream(source)),
       [
-        new SourceLocation(STRING_START, 0),
+        new SourceLocation(TDSTRING_START, 0),
         new SourceLocation(SPACE, 3),
         new SourceLocation(STRING_CONTENT, 10),
         new SourceLocation(INTERPOLATION_START, 11),
@@ -82,7 +93,7 @@ describe('tripleQuotedStringSourceLocations', () => {
         new SourceLocation(INTERPOLATION_END, 28),
         new SourceLocation(STRING_CONTENT, 29),
         new SourceLocation(SPACE, 30),
-        new SourceLocation(STRING_END, 37)
+        new SourceLocation(TDSTRING_END, 37)
       ]
     )
   });
@@ -90,9 +101,9 @@ describe('tripleQuotedStringSourceLocations', () => {
   it('returns an array with empty leading and trailing string content tokens for a string containing only an interpolation', () => {
     let source = `"""\n#{a}\n"""`;
     deepEqual(
-      getTripleQuotedStringSemanticRanges(source, bufferedStream(source)),
+      getTripleQuotedStringSourceLocations(source, bufferedStream(source)),
       [
-        new SourceLocation(STRING_START, 0),
+        new SourceLocation(TDSTRING_START, 0),
         new SourceLocation(SPACE, 3),
         new SourceLocation(STRING_CONTENT, 4),
         new SourceLocation(INTERPOLATION_START, 4),
@@ -100,7 +111,7 @@ describe('tripleQuotedStringSourceLocations', () => {
         new SourceLocation(INTERPOLATION_END, 7),
         new SourceLocation(STRING_CONTENT, 8),
         new SourceLocation(SPACE, 8),
-        new SourceLocation(STRING_END, 9)
+        new SourceLocation(TDSTRING_END, 9)
       ]
     )
   });
@@ -108,9 +119,9 @@ describe('tripleQuotedStringSourceLocations', () => {
   it('returns an array with empty string content token between adjacent interpolations', () => {
     let source = `"""#{a}#{b}"""`;
     deepEqual(
-      getTripleQuotedStringSemanticRanges(source, bufferedStream(source)),
+      getTripleQuotedStringSourceLocations(source, bufferedStream(source)),
       [
-        new SourceLocation(STRING_START, 0),
+        new SourceLocation(TDSTRING_START, 0),
         new SourceLocation(STRING_CONTENT, 3),
         new SourceLocation(INTERPOLATION_START, 3),
         new SourceLocation(IDENTIFIER, 5),
@@ -120,7 +131,7 @@ describe('tripleQuotedStringSourceLocations', () => {
         new SourceLocation(IDENTIFIER, 9),
         new SourceLocation(INTERPOLATION_END, 10),
         new SourceLocation(STRING_CONTENT, 11),
-        new SourceLocation(STRING_END, 11)
+        new SourceLocation(TDSTRING_END, 11)
       ]
     )
   });
@@ -129,11 +140,11 @@ describe('tripleQuotedStringSourceLocations', () => {
     let source = `"""abc""" + 99`;
     let stream = bufferedStream(source);
     deepEqual(
-      getTripleQuotedStringSemanticRanges(source, stream),
+      getTripleQuotedStringSourceLocations(source, stream),
       [
-        new SourceLocation(STRING_START, 0),
+        new SourceLocation(TDSTRING_START, 0),
         new SourceLocation(STRING_CONTENT, 3),
-        new SourceLocation(STRING_END, 6)
+        new SourceLocation(TDSTRING_END, 6)
       ]
     );
     deepEqual(


### PR DESCRIPTION
Progress toward https://github.com/decaffeinate/decaffeinate/issues/557

After this change, all four types of strings are treated similarly: they're
generated initially with `[type]_START`, `STRING_CONTENT`, and `[type]_END`,
potentially with interpolations, then later code might process them further. The
`tripleQuotedStringSourceLocations` function behaves the same and was changed to
recognize the new format and output the same format as before.

I intentionally split `STRING_START` and `STRING_END` into four types, since
later code will want to look at the actual type to know how to compute the
whitespace to strip.

BREAKING CHANGE: The TDSTRING, TSSTRING, STRING_START, and STRING_END tokens
have been removed. Instead, strings always have a specific start and end token
for their type of string, e.g. SSTRING_START and SSTRING_END.