### PR TITLE
feat: add basic lexing for string interpolations in heregexes

### DIFF
--- a/src/coffee-lex.js.flow
+++ b/src/coffee-lex.js.flow
@@ -80,7 +80,8 @@ declare var FINALLY: SourceType;
 declare var FOR: SourceType;
 declare var FUNCTION: SourceType;
 declare var HERECOMMENT: SourceType;
-declare var HEREGEXP: SourceType;
+declare var HEREGEXP_END: SourceType;
+declare var HEREGEXP_START: SourceType;
 declare var IF: SourceType;
 declare var INTERPOLATION_START: SourceType;
 declare var INTERPOLATION_END: SourceType;
@@ -158,7 +159,8 @@ export {
   FOR,
   FUNCTION,
   HERECOMMENT,
-  HEREGEXP,
+  HEREGEXP_END,
+  HEREGEXP_START,
   IF,
   INTERPOLATION_START,
   INTERPOLATION_END,

--- a/test/test.js
+++ b/test/test.js
@@ -30,6 +30,8 @@ import lex, {
   FOR,
   FUNCTION,
   HERECOMMENT,
+  HEREGEXP_END,
+  HEREGEXP_START,
   IDENTIFIER,
   IF,
   INTERPOLATION_END,
@@ -939,6 +941,46 @@ describe('stream', () => {
         new SourceLocation(STRING_CONTENT, 12),
         new SourceLocation(SSTRING_END, 15),
         new SourceLocation(EOF, 16)
+      ]
+    )
+  );
+
+  it('identifies simple heregexes', () =>
+    checkLocations(
+      stream(`///abc///g.test 'foo'`),
+      [
+        new SourceLocation(HEREGEXP_START, 0),
+        new SourceLocation(STRING_CONTENT, 3),
+        new SourceLocation(HEREGEXP_END, 6),
+        new SourceLocation(DOT, 10),
+        new SourceLocation(IDENTIFIER, 11),
+        new SourceLocation(SPACE, 15),
+        new SourceLocation(SSTRING_START, 16),
+        new SourceLocation(STRING_CONTENT, 17),
+        new SourceLocation(SSTRING_END, 20),
+        new SourceLocation(EOF, 21)
+      ]
+    )
+  );
+
+  it('identifies heregexes with interpolations', () =>
+    checkLocations(
+      stream(`///abc\ndef#{g}  # this is a comment\nhij///g.test 'foo'`),
+      [
+        new SourceLocation(HEREGEXP_START, 0),
+        new SourceLocation(STRING_CONTENT, 3),
+        new SourceLocation(INTERPOLATION_START, 10),
+        new SourceLocation(IDENTIFIER, 12),
+        new SourceLocation(INTERPOLATION_END, 13),
+        new SourceLocation(STRING_CONTENT, 14),
+        new SourceLocation(HEREGEXP_END, 39),
+        new SourceLocation(DOT, 43),
+        new SourceLocation(IDENTIFIER, 44),
+        new SourceLocation(SPACE, 48),
+        new SourceLocation(SSTRING_START, 49),
+        new SourceLocation(STRING_CONTENT, 50),
+        new SourceLocation(SSTRING_END, 53),
+        new SourceLocation(EOF, 54)
       ]
     )
   );


### PR DESCRIPTION
Progress toward https://github.com/decaffeinate/decaffeinate/issues/557

I was originally planning to make normal regexes use the same strategy, but it
looks like regex lexing is tricky, probably because the `/` character could also
mean division. So we only use the `[type]_START`, `STRING_CONTENT`, `[type]_END`
approach for heregexes and strings.

BREAKING CHANGE: The HEREGEXP token type has been replaced with HEREGEXP_START
and HEREGEXP_END.