### PR TITLE
feat: calculate padding for heregexes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,8 @@ import SourceLocation from './SourceLocation.js';
 import SourceToken from './SourceToken.js';
 import SourceTokenList from './SourceTokenList.js';
 import SourceType from './SourceType.js';
-import calculateNormalStringPadding from './utils/calculateNormalStringPadding';
+import calculateNormalStringPadding from './utils/calculateNormalStringPadding.js';
+import calculateHeregexpPadding from './utils/calculateHeregexpPadding.js';
 import tripleQuotedStringSourceLocations from './utils/tripleQuotedStringSourceLocations.js';
 
 /**
@@ -22,6 +23,9 @@ export default function lex(source: string): SourceTokenList {
     );
     pending.unshift(
       ...tripleQuotedStringSourceLocations(source, pending)
+    );
+    pending.unshift(
+      ...calculateHeregexpPadding(source, pending)
     );
     pending.unshift(
       ...combinedLocationsForMultiwordOperators(pending, source)

--- a/src/utils/calculateHeregexpPadding.js
+++ b/src/utils/calculateHeregexpPadding.js
@@ -1,0 +1,58 @@
+/* @flow */
+import { HEREGEXP_START, HEREGEXP_END } from '../index.js';
+import PaddingTracker from './PaddingTracker';
+
+import type BufferedStream from './BufferedStream.js';
+import type SourceLocation from '../SourceLocation.js';
+
+/**
+ * Compute the whitespace to remove in a heregexp. All unescaped whitespace
+ * characters are removed, and comments are respected.
+ */
+export default function calculateHeregexpPadding(source: string, stream: BufferedStream): Array<SourceLocation> {
+  if (!stream.hasNext(HEREGEXP_START)) {
+    return [];
+  }
+  let paddingTracker = new PaddingTracker(source, stream, HEREGEXP_END);
+
+  for (let fragment of paddingTracker.fragments) {
+    let content = fragment.content;
+    let pos = 0;
+    while (pos < content.length) {
+      if (isWhitespace(content[pos])) {
+        if (isWhitespaceEscaped(content, pos)) {
+          // The escape character should be removed instead of the space.
+          fragment.markPadding(pos - 1, pos);
+        } else {
+          fragment.markPadding(pos, pos + 1);
+        }
+        pos++;
+      } else if (content[pos] === '#' && (pos === 0 || isWhitespace(content[pos - 1]))) {
+        let commentStart = pos;
+        while (pos < content.length && content[pos] !== '\n') {
+          pos++;
+        }
+        fragment.markPadding(commentStart, pos);
+      } else {
+        pos++;
+      }
+    }
+  }
+  return paddingTracker.computeSourceLocations();
+}
+
+function isWhitespace(char) {
+  return char === ' ' || char === '\t' || char === '\n';
+}
+
+/**
+ * A space, tab, or newline is escaped if it is preceded by an odd number of
+ * backslashes.
+ */
+function isWhitespaceEscaped(content: string, whitespacePos: number): boolean {
+  let prevPos = whitespacePos - 1;
+  while (prevPos >= 0 && content[prevPos] === '\\') {
+    prevPos--;
+  }
+  return (whitespacePos - prevPos) % 2 == 0;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1012,6 +1012,29 @@ describe('stream', () => {
     )
   );
 
+  it('computes the right padding for heregexes with interpolations', () =>
+    deepEqual(
+      lex(`///abc\ndef#{g}  # this is a comment\nhij///g.test 'foo'`).toArray(),
+      [
+        new SourceToken(HEREGEXP_START, 0, 3),
+        new SourceToken(STRING_CONTENT, 3, 6),
+        new SourceToken(STRING_PADDING, 6, 7),
+        new SourceToken(STRING_CONTENT, 7, 10),
+        new SourceToken(INTERPOLATION_START, 10, 12),
+        new SourceToken(IDENTIFIER, 12, 13),
+        new SourceToken(INTERPOLATION_END, 13, 14),
+        new SourceToken(STRING_PADDING, 14, 36),
+        new SourceToken(STRING_CONTENT, 36, 39),
+        new SourceToken(HEREGEXP_END, 39, 43),
+        new SourceToken(DOT, 43, 44),
+        new SourceToken(IDENTIFIER, 44, 48),
+        new SourceToken(SSTRING_START, 49, 50),
+        new SourceToken(STRING_CONTENT, 50, 53),
+        new SourceToken(SSTRING_END, 53, 54),
+      ]
+    )
+  );
+
   it('identifies keywords for conditionals', () =>
     checkLocations(
       stream(`if a then b else c`),

--- a/test/utils/calculateHeregexpPadding_test.js
+++ b/test/utils/calculateHeregexpPadding_test.js
@@ -1,0 +1,62 @@
+import verifyStringMatchesCoffeeScript from './verifyStringMatchesCoffeeScript.js';
+
+describe('calculateHeregexpPadding', () => {
+  it('removes whitespace from single-line heregexes', () => {
+    verifyStringMatchesCoffeeScript(`///a b///`, ['ab']);
+  });
+
+  it('handles heregexp comments', () => {
+    verifyStringMatchesCoffeeScript(`///
+    b  # foo
+    c
+    ///`, ['bc']);
+  });
+
+  it('does not treat # as a comment if it is preceded by non-whitespace', () => {
+    verifyStringMatchesCoffeeScript(`///
+    b# foo
+    c
+    ///`, ['b#fooc']);
+  });
+
+  it('handles interpolations within heregexes', () => {
+    verifyStringMatchesCoffeeScript(`///
+    a  #{b}
+    c
+    ///`, ['a', 'c']);
+  });
+
+  it('allows interpolations in comments and ends the comment at the interpolation', () => {
+    verifyStringMatchesCoffeeScript(`///
+    a #b #{c}d
+    e
+    ///`, ['a', 'de']);
+  });
+
+  it('allows escaped spaces in heregexes', () => {
+    verifyStringMatchesCoffeeScript(`///
+    a \\ b #{c}d
+    e
+    ///`, ['a b', 'de']);
+  });
+
+  it('does not escape a space on a double backslash', () => {
+    verifyStringMatchesCoffeeScript(`///
+    a \\\\ b #{c}d
+    e
+    ///`, ['a\\\\\\\\b', 'de']);
+  });
+
+  it('escapes a space on a triple backslash', () => {
+    verifyStringMatchesCoffeeScript(`///
+    a \\\\\\ b #{c}d
+    e
+    ///`, ['a\\\\\\\\ b', 'de']);
+  });
+
+  it('handles a hergexp consisting of only a backslash', () => {
+    verifyStringMatchesCoffeeScript(`///
+    \\a
+    ///`, ['\\\\a']);
+  });
+});

--- a/test/utils/calculateNormalStringPadding_test.js
+++ b/test/utils/calculateNormalStringPadding_test.js
@@ -1,106 +1,59 @@
-import * as CoffeeScript from 'decaffeinate-coffeescript';
-
-import BufferedStream from '../../src/utils/BufferedStream.js';
-import calculateNormalStringPadding from '../../src/utils/calculateNormalStringPadding.js';
-import {
-  INTERPOLATION_START,
-  STRING_CONTENT,
-  STRING_LINE_SEPARATOR,
-  stream
-} from '../../src/index.js';
-import { deepEqual } from 'assert';
+import verifyStringMatchesCoffeeScript from './verifyStringMatchesCoffeeScript.js';
 
 describe('calculateNormalStringPadding', () => {
   it('does not strip whitespace in a string with no newlines', () => {
-    verifyStringMatchesCoffeeScript(`  a b  `, ['  a b  ']);
+    verifyStringMatchesCoffeeScript(`"  a b  "`, ['  a b  ']);
   });
 
   it('inserts spaces for newlines', () => {
-    verifyStringMatchesCoffeeScript(`
+    verifyStringMatchesCoffeeScript(`"
       a
       b
-    `, ['a b']);
+    "`, ['a b']);
   });
 
   it('removes spaces when there is an interpolation', () => {
-    verifyStringMatchesCoffeeScript(`
+    verifyStringMatchesCoffeeScript(`"
       a  #{b}
       c
-    `, ['a  ', ' c']);
+    "`, ['a  ', ' c']);
   });
 
   it('does not remove spaces when the only newline is across an interpolation', () => {
-    verifyStringMatchesCoffeeScript(` a #{
-  b} c `, [' a ', ' c ']);
+    verifyStringMatchesCoffeeScript(`" a #{
+  b} c "`, [' a ', ' c ']);
   });
 
   it('removes leading and trailing tab characters', () => {
-    verifyStringMatchesCoffeeScript(`
+    verifyStringMatchesCoffeeScript(`"
 \ta
     b\t
-`, ['a b']);
+"`, ['a b']);
   });
 
   it('does not add an intermediate space when a newline is escaped', () => {
-    verifyStringMatchesCoffeeScript(`a\\
-b`, ['ab']);
+    verifyStringMatchesCoffeeScript(`"a\\
+b"`, ['ab']);
   });
 
   it('adds an intermediate space on a double backslash', () => {
-    verifyStringMatchesCoffeeScript(`a\\\\
-b`, ['a\\\\ b']);
+    verifyStringMatchesCoffeeScript(`"a\\\\
+b"`, ['a\\\\ b']);
   });
 
   it('does not add an intermediate space on a triple backslash', () => {
-    verifyStringMatchesCoffeeScript(`a\\\\\\
-b`, ['a\\\\b']);
+    verifyStringMatchesCoffeeScript(`"a\\\\\\
+b"`, ['a\\\\b']);
   });
 
   it('does not remove spaces to the left of an escaped newline', () => {
-    verifyStringMatchesCoffeeScript(`a   \\
-b`, ['a   b']);
+    verifyStringMatchesCoffeeScript(`"a   \\
+b"`, ['a   b']);
   });
 
   it('treats a backslash, then spaces, then a newline as an escaped newline', () => {
-    verifyStringMatchesCoffeeScript(`
+    verifyStringMatchesCoffeeScript(`"
 a\\  
-b`, ['ab']);
+b"`, ['ab']);
   });
-
-  function verifyStringMatchesCoffeeScript(stringContents, expectedQuasis) {
-    let code = `"${stringContents}"`;
-    let coffeeLexResult = getCoffeeLexQuasis(code);
-    let coffeeScriptResult = getCoffeeScriptQuasis(code);
-    deepEqual(coffeeLexResult, coffeeScriptResult);
-    deepEqual(coffeeLexResult, expectedQuasis);
-  }
-
-  function getCoffeeLexQuasis(code) {
-    let bufferedStream = new BufferedStream(stream(code));
-    let locations = calculateNormalStringPadding(code, bufferedStream);
-    let quasis = [''];
-    for (let i = 0; i < locations.length - 1; i++) {
-      if (locations[i].type === STRING_CONTENT) {
-        quasis[quasis.length - 1] += code.slice(locations[i].index, locations[i + 1].index);
-      } else if (locations[i].type === STRING_LINE_SEPARATOR) {
-        quasis[quasis.length - 1] += ' ';
-      } else if (locations[i].type === INTERPOLATION_START) {
-        quasis.push('');
-      }
-    }
-    return quasis;
-  }
-
-  function getCoffeeScriptQuasis(code) {
-    let tokens = CoffeeScript.tokens(code);
-    let resultQuasis = [];
-    for (let token of tokens) {
-      if (token[0] === 'STRING') {
-        resultQuasis.push(
-          JSON.parse(token[1].replace(/\t/g, '\\t')).replace(/\\/, '\\\\')
-        );
-      }
-    }
-    return resultQuasis;
-  }
 });

--- a/test/utils/verifyStringMatchesCoffeeScript.js
+++ b/test/utils/verifyStringMatchesCoffeeScript.js
@@ -1,0 +1,68 @@
+import { deepEqual } from 'assert';
+import * as CoffeeScript from 'decaffeinate-coffeescript';
+
+import lex, {
+  HEREGEXP_START,
+  INTERPOLATION_START,
+  STRING_CONTENT,
+  STRING_LINE_SEPARATOR
+} from '../../src/index.js';
+
+/**
+ * Given code containing a string, herestring, or heregex, verify that the
+ * quasis have the expected values, and run the same code through the
+ * CoffeeScript lexer to verify that the values match.
+ *
+ * This function uses a simple and imperfect algorithm to extract the string
+ * contents from the coffee-lex and CoffeeScript output, so it should only be
+ * given relatively simple cases, e.g. no string literals within interpolations.
+ * It can always be made more advanced if more complicated cases are useful to
+ * test.
+ */
+export default function verifyStringMatchesCoffeeScript(code, expectedQuasis) {
+  let coffeeLexResult = getCoffeeLexQuasis(code);
+  let coffeeScriptResult = getCoffeeScriptQuasis(code);
+  deepEqual(coffeeLexResult, coffeeScriptResult);
+  deepEqual(coffeeLexResult, expectedQuasis);
+}
+
+function getCoffeeLexQuasis(code) {
+  let tokens = lex(code);
+  let quasis = [''];
+  tokens.forEach(token => {
+    if (token.type === STRING_CONTENT) {
+      quasis[quasis.length - 1] += code.slice(token.start, token.end);
+    } else if (token.type === STRING_LINE_SEPARATOR) {
+      quasis[quasis.length - 1] += ' ';
+    } else if (token.type === INTERPOLATION_START) {
+      quasis.push('');
+    }
+  });
+  // As a special case, if this is a heregexp, escaping rules are different, so
+  // convert backslash to double backslash. Code using coffee-lex is responsible
+  // for adding these escape characters.
+  if (tokens.toArray()[0].type === HEREGEXP_START) {
+    quasis = quasis.map(str => str.replace(/\\/g, '\\\\'));
+  }
+  return quasis;
+}
+
+function getCoffeeScriptQuasis(code) {
+  let tokens = CoffeeScript.tokens(code);
+  let resultQuasis = [];
+  for (let token of tokens) {
+    if (token[0] === 'STRING') {
+      resultQuasis.push(
+        JSON.parse(token[1].replace(/\t/g, '\\t')).replace(/\\/g, '\\\\')
+      );
+    } else if (token[0] === 'REGEX') {
+      let stringForm = `"${token[1].slice(1, -1)}"`
+        .replace(/\\/g, '\\\\')
+        .replace(/\t/g, '\\t');
+      resultQuasis.push(
+        JSON.parse(stringForm).replace(/\\/g, '\\\\')
+      );
+    }
+  }
+  return resultQuasis;
+}


### PR DESCRIPTION
Progress toward these issues:
https://github.com/decaffeinate/decaffeinate/issues/557
https://github.com/decaffeinate/decaffeinate/issues/341

Heregexes have relatively simple rules for whitespace padding, but there is some
complexity because I needed to handle comments and escaped spaces.

This change also refactors the test code to be shared.