### PR TITLE
fix: rework herestring padding to better agree with CoffeeScript

### DIFF
--- a/src/utils/PaddingTracker.js
+++ b/src/utils/PaddingTracker.js
@@ -49,7 +49,8 @@ export default class PaddingTracker {
         let start = location.index;
         let end = stream.peek().index;
         let content = source.slice(start, end);
-        this.fragments.push(new TrackedFragment(content, start, end));
+        let index = this.fragments.length;
+        this.fragments.push(new TrackedFragment(content, start, end, index));
       } else if (location.type === INTERPOLATION_START) {
         interpolationLevel += 1;
       } else if (location.type === INTERPOLATION_END) {
@@ -85,13 +86,15 @@ export class TrackedFragment {
   content: string;
   start: number;
   end: number;
+  index: number;
   _paddingRanges: Array<PaddingRange>;
   _lineSeparators: Array<number>;
 
-  constructor(content: string, start: number, end: number) {
+  constructor(content: string, start: number, end: number, index: number) {
     this.content = content;
     this.start = start;
     this.end = end;
+    this.index = index;
     this._paddingRanges = [];
     this._lineSeparators = [];
   }

--- a/test/utils/calculateTripleQuotedStringPadding_test.js
+++ b/test/utils/calculateTripleQuotedStringPadding_test.js
@@ -17,7 +17,7 @@ import verifyStringMatchesCoffeeScript from './verifyStringMatchesCoffeeScript.j
 
 describe('tripleQuotedStringSourceLocations', () => {
   it('returns an empty string for an empty triple-quoted string', () => {
-    verifyStringMatchesCoffeeScript(`''''''`, ['']);
+    verifyStringMatchesCoffeeScript(`''''''`, []);
   });
 
   it('marks a leading and trailing newline as padding', () => {
@@ -45,12 +45,12 @@ describe('tripleQuotedStringSourceLocations', () => {
     );
   });
 
-  it.skip('ignores the indentation level of the first line in herestrings', () => {
+  it('ignores the indentation level of the first line in herestrings', () => {
     verifyStringMatchesCoffeeScript(`'''a
       b'''`, ['a\nb']);
   });
 
-  it.skip('removes leading nonempty indentation in herestrings', () => {
+  it('removes leading nonempty indentation in herestrings', () => {
     verifyStringMatchesCoffeeScript(`'''
  a
   b
@@ -58,7 +58,7 @@ c
 d'''`, ['a\n b\nc\nd']);
   });
 
-  it.skip('preserves leading indentation on the first line in herestrings if necessary', () => {
+  it('preserves leading indentation on the first line in herestrings if necessary', () => {
     verifyStringMatchesCoffeeScript(`''' a
           b
             c
@@ -89,7 +89,7 @@ d'''`, ['a\n  b\n c\nd']);
       [' a\n  b\nc\n  d']);
   });
 
-  it.skip('keeps spacing in the second line if there are two lines and both are only whitespace', () => {
+  it('keeps spacing in the second line if there are two lines and both are only whitespace', () => {
     verifyStringMatchesCoffeeScript(`'''    
    '''`,
       ['   ']);
@@ -109,7 +109,7 @@ a
       ['a']);
   });
 
-  it.skip('handles a string with a blank line with spaces in it', () => {
+  it('handles a string with a blank line with spaces in it', () => {
     verifyStringMatchesCoffeeScript(`'''
   a
  
@@ -123,6 +123,13 @@ a
   b
  '''`,
       ['a\nb']);
+  });
+
+  it('keeps leading spaces in a herestring with interpolations', () => {
+    verifyStringMatchesCoffeeScript(`"""    a
+b#{c}
+"""`,
+      ['    a\nb']);
   });
 
   it('returns an array with empty leading and trailing string content tokens for a string containing only an interpolation', () => {

--- a/test/utils/verifyStringMatchesCoffeeScript.js
+++ b/test/utils/verifyStringMatchesCoffeeScript.js
@@ -16,8 +16,9 @@ import lex, {
  * This function uses a simple and imperfect algorithm to extract the string
  * contents from the coffee-lex and CoffeeScript output, so it should only be
  * given relatively simple cases, e.g. no string literals within interpolations.
- * It can always be made more advanced if more complicated cases are useful to
- * test.
+ * Also, empty quasis are removed to account for unimportant differences between
+ * coffee-lex and the CoffeeScript lexer. It can always be made more advanced if
+ * more complicated cases are useful to test.
  */
 export default function verifyStringMatchesCoffeeScript(code, expectedQuasis) {
   let coffeeLexResult = getCoffeeLexQuasis(code);
@@ -52,7 +53,7 @@ function getCoffeeLexQuasis(code) {
   if (tokens.toArray()[0].type === HEREGEXP_START) {
     quasis = quasis.map(str => str.replace(/\\/g, '\\\\'));
   }
-  return quasis;
+  return quasis.filter(quasi => quasi.length > 0);
 }
 
 function getCoffeeScriptQuasis(code) {
@@ -76,5 +77,5 @@ function getCoffeeScriptQuasis(code) {
       );
     }
   }
-  return resultQuasis;
+  return resultQuasis.filter(quasi => quasi.length > 0);
 }


### PR DESCRIPTION
Progress toward these issues:
https://github.com/decaffeinate/decaffeinate/issues/557
https://github.com/decaffeinate/decaffeinate/issues/556

There are a number of edge cases in dealing with herestring padding that are
handled in decaffeinate-parser but weren't properly handled in coffee-lex, so
this change ports those changes over using the PaddingTracker approach, which
also means that the padding strategy works for interpolations.