### PR TITLE
fix: include heregex tokens when determining interpolated string ranges

### DIFF
--- a/src/SourceTokenList.js
+++ b/src/SourceTokenList.js
@@ -3,7 +3,7 @@
 import SourceToken from './SourceToken.js';
 import SourceTokenListIndex from './SourceTokenListIndex.js';
 import SourceType from './SourceType.js';
-import { DSTRING_START, DSTRING_END, TDSTRING_START, TDSTRING_END } from './index.js';
+import { DSTRING_START, DSTRING_END, HEREGEXP_START, HEREGEXP_END, TDSTRING_START, TDSTRING_END } from './index.js';
 
 type SourceTokenListIndexRange = [SourceTokenListIndex, SourceTokenListIndex];
 
@@ -83,7 +83,8 @@ export default class SourceTokenList {
    */
   rangeOfInterpolatedStringTokensContainingTokenIndex(index: SourceTokenListIndex): ?SourceTokenListIndexRange {
     let bestRange = null;
-    for (let [startType, endType] of [[DSTRING_START, DSTRING_END], [TDSTRING_START, TDSTRING_END]]) {
+    for (let [startType, endType] of [
+        [DSTRING_START, DSTRING_END], [TDSTRING_START, TDSTRING_END], [HEREGEXP_START, HEREGEXP_END]]) {
       let range = this.rangeOfMatchingTokensContainingTokenIndex(
         startType,
         endType,

--- a/test/test.js
+++ b/test/test.js
@@ -542,6 +542,31 @@ describe('SourceTokenList', () => {
     strictEqual(range[1], list.endIndex);
   });
 
+  it('can determine the interpolated string range for a heregex', () => {
+    let list = lex('///a#{b}c///');
+
+    deepEqual(
+      list.map(t => t.type),
+      [
+        HEREGEXP_START,
+        STRING_CONTENT,
+        INTERPOLATION_START,
+        IDENTIFIER,
+        INTERPOLATION_END,
+        STRING_CONTENT,
+        HEREGEXP_END,
+      ]
+    );
+
+    // Go past HEREGEXP_START & STRING_CONTENT.
+    let interpolationStart = list.startIndex.advance(2);
+    let range = list.rangeOfInterpolatedStringTokensContainingTokenIndex(
+      interpolationStart
+    );
+    strictEqual(range[0], list.startIndex);
+    strictEqual(range[1], list.endIndex);
+  });
+
   it('allows comparing indexes', () => {
     let list = lex('a b');
     let { startIndex, endIndex } = list;


### PR DESCRIPTION
Progress toward these issues:
https://github.com/decaffeinate/decaffeinate/issues/557
https://github.com/decaffeinate/decaffeinate/issues/341

This should let decaffeinate-parser determine heregex locations without having
to jump through additional hoops.