### PR TITLE
feat: improve performance in SourceTokenList

### DIFF
--- a/src/SourceToken.ts
+++ b/src/SourceToken.ts
@@ -6,6 +6,9 @@ export default class SourceToken {
   end: number;
 
   constructor(type: SourceType, start: number, end: number) {
+    if (start > end) {
+      throw new Error(`Token start may not be after end. Got ${type}, ${start}, ${end}`);
+    }
     this.type = type;
     this.start = start;
     this.end = end;

--- a/test/test.ts
+++ b/test/test.ts
@@ -403,6 +403,23 @@ describe('SourceTokenListTest', () => {
     strictEqual(list.indexOfTokenContainingSourceIndex(9), null);      // <EOF>
   });
 
+  it('allows getting a nearby token index by source index', () => {
+    let list = lex('one + two');
+    let oneIndex = list.startIndex;
+    let plusIndex = oneIndex.next();
+    let twoIndex = plusIndex && plusIndex.next();
+    strictEqual(list.indexOfTokenNearSourceIndex(0), oneIndex);  // o
+    strictEqual(list.indexOfTokenNearSourceIndex(1), oneIndex);  // n
+    strictEqual(list.indexOfTokenNearSourceIndex(2), oneIndex);  // e
+    strictEqual(list.indexOfTokenNearSourceIndex(3), oneIndex);  //
+    strictEqual(list.indexOfTokenNearSourceIndex(4), plusIndex); // +
+    strictEqual(list.indexOfTokenNearSourceIndex(5), plusIndex); //
+    strictEqual(list.indexOfTokenNearSourceIndex(6), twoIndex);  // t
+    strictEqual(list.indexOfTokenNearSourceIndex(7), twoIndex);  // w
+    strictEqual(list.indexOfTokenNearSourceIndex(8), twoIndex);  // o
+    strictEqual(list.indexOfTokenNearSourceIndex(9), twoIndex);  // <EOF>
+  });
+
   it('allows getting a token index by its starting source index', () => {
     let list = lex('one + two');
     let oneIndex = list.startIndex;
@@ -435,6 +452,44 @@ describe('SourceTokenListTest', () => {
     strictEqual(list.indexOfTokenEndingAtSourceIndex(7), null);      // w
     strictEqual(list.indexOfTokenEndingAtSourceIndex(8), null);      // o
     strictEqual(list.indexOfTokenEndingAtSourceIndex(9), twoIndex);  // <EOF>
+  });
+
+  it('allows searching through a token index range by a predicate', () => {
+    let list = lex('one + two');
+    let oneIndex = list.startIndex;
+    let plusIndex = oneIndex.next();
+    let twoIndex = plusIndex && plusIndex.next();
+    strictEqual(
+      list.indexOfTokenMatchingPredicate(token => token.type === IDENTIFIER),
+      oneIndex
+    );
+    strictEqual(
+      list.indexOfTokenMatchingPredicate(token => token.type === IDENTIFIER, plusIndex),
+      twoIndex
+    );
+    strictEqual(
+      list.indexOfTokenMatchingPredicate(token => token.type === IDENTIFIER, plusIndex, twoIndex),
+      null
+    );
+  });
+
+  it('allows searching backwards through a token index range by a predicate', () => {
+    let list = lex('one + two');
+    let oneIndex = list.startIndex;
+    let plusIndex = oneIndex.next();
+    let twoIndex = plusIndex && plusIndex.next();
+    strictEqual(
+      list.lastIndexOfTokenMatchingPredicate(token => token.type === IDENTIFIER),
+      twoIndex
+    );
+    strictEqual(
+      list.lastIndexOfTokenMatchingPredicate(token => token.type === IDENTIFIER, plusIndex),
+      oneIndex
+    );
+    strictEqual(
+      list.lastIndexOfTokenMatchingPredicate(token => token.type === IDENTIFIER, plusIndex, oneIndex),
+      null
+    );
   });
 
   it('allows getting the range of an interpolated string by source index', () => {


### PR DESCRIPTION
Progress toward https://github.com/decaffeinate/decaffeinate/issues/612

SourceTokenList usage is the main (maybe only) case where decaffeinate has
behavior that can be O(n^2) in the size of the source code, so this commit fixes
some linear scans and extends the API to allow calling code to avoid linear
scans:
* `indexOfTokenContainingSourceIndex` and friends were all doing a linear scan
  through all tokens to find one at the right index. Instead, I precompute a
  table mapping source index to token index and just do a fast lookup in that
  table. (I also considered binary search, but the table approach is simpler and
  a little faster and I think the memory usage isn't a concern).
* `indexOfTokenMatchingPredicate` and `lastIndexOfTokenMatchingPredicate`
  allowed you to optionally specify a start index, but not an end index. I added
  the ability to specify an end index, which means that you can always have a
  reasonable bound on the number of tokens searched.
* I added an `indexOfTokenNearSourceIndex` method that always returns some
  token index, even if the source index lands on whitespace. This means that you
  can always turn a source range into a token range without worrying about not
  landing on a token.

Also, I added some validation to make sure tokens are always in order, which
turns out to be true.