### PR TITLE
chore(package): update dependencies

### DIFF
--- a/declarations/decaffeinate-coffeescript.d.ts
+++ b/declarations/decaffeinate-coffeescript.d.ts
@@ -1,4 +1,0 @@
-declare module 'decaffeinate-coffeescript' {
-  export type Token = [string, string];
-  export function tokens(source: string): Array<Token>;
-}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "scripts": {
-    "prebuild": "rm -rf dist/",
     "build": "./script/build",
     "lint": "tslint --config tslint.json --project tsconfig.json --type-check",
     "lint-fix": "tslint --config tslint.json --project tsconfig.json --type-check --fix",
@@ -35,10 +34,10 @@
   "homepage": "https://github.com/decaffeinate/coffee-lex",
   "devDependencies": {
     "@types/mocha": "^2.2.33",
-    "@types/node": "^6.0.51",
-    "decaffeinate-coffeescript": "^1.10.0-patch5",
+    "@types/node": "^6.0.52",
+    "decaffeinate-coffeescript": "^1.10.0-patch7",
     "mocha": "^3.2.0",
-    "semantic-release": "^6.3.2",
+    "semantic-release": "^6.3.5",
     "ts-node": "^1.7.2",
     "tslint": "^4.0.2",
     "typescript": "^2.1.4"

--- a/script/build
+++ b/script/build
@@ -5,14 +5,25 @@ set -e
 DIST="${DIST:-dist}"
 TSC="${TSC:-node_modules/.bin/tsc}"
 
-# Build ES module version.
-"${TSC}" --project . --outDir "${DIST}" --module ES6
+rm -rf "${DIST}"
+
+echo 'Building ES module version.'
+"${TSC}" \
+  --project . \
+  --outDir "${DIST}" \
+  --module ES2015 \
+  --moduleResolution node
+
 for js in $(find "${DIST}" -name '*.js'); do
   mv "${js}" "$(dirname "${js}")/$(basename "${js}" .js).mjs"
 done
 
-# Build CommonJS version.
-"${TSC}" --project . --outDir "${DIST}" --module commonjs
+echo 'Building CommonJS version.'
+"${TSC}" \
+  --project . \
+  --outDir "${DIST}" \
+  --module commonjs \
+  --moduleResolution node
 
 # Restructure.
 rm -rf dist/test

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strictNullChecks": true,
     "module": "commonjs",
-    "typeRoots": ["declarations", "node_modules/@types"],
+    "typeRoots": ["node_modules/@types"],
     "declaration": true,
     "lib": ["es2015"],
     "experimentalDecorators": true,


### PR DESCRIPTION
Updating to decaffeinate-coffeescript@1.10.0-patch6 means we get the type information from the included `.d.ts` files, so we can ditch the simplified one in `declarations`.