### PR TITLE
fix: ensure multiple copies of coffee-lex can coexist

### DIFF
--- a/src/SourceTokenList.ts
+++ b/src/SourceTokenList.ts
@@ -1,4 +1,3 @@
-import { DSTRING_END, DSTRING_START, HEREGEXP_END, HEREGEXP_START, TDSTRING_END, TDSTRING_START } from './index';
 import SourceToken from './SourceToken';
 import SourceTokenListIndex from './SourceTokenListIndex';
 import SourceType from './SourceType';
@@ -100,7 +99,7 @@ export default class SourceTokenList {
   rangeOfInterpolatedStringTokensContainingTokenIndex(index: SourceTokenListIndex): SourceTokenListIndexRange | null {
     let bestRange: SourceTokenListIndexRange | null = null;
     for (let [startType, endType] of [
-        [DSTRING_START, DSTRING_END], [TDSTRING_START, TDSTRING_END], [HEREGEXP_START, HEREGEXP_END]]) {
+        [SourceType.DSTRING_START, SourceType.DSTRING_END], [SourceType.TDSTRING_START, SourceType.TDSTRING_END], [SourceType.HEREGEXP_START, SourceType.HEREGEXP_END]]) {
       let range = this.rangeOfMatchingTokensContainingTokenIndex(
         startType,
         endType,

--- a/src/SourceType.ts
+++ b/src/SourceType.ts
@@ -1,14 +1,78 @@
 /**
  * Represents a particular type of CoffeeScript code.
  */
-export default class SourceType {
-  name: string;
-
-  constructor(name: string) {
-    this.name = name;
-  }
-  
-  toString(): string {
-    return this.name;
-  }
+enum SourceType {
+  AT = 1,
+  BOOL = 2,
+  BREAK = 3,
+  CATCH = 4,
+  CALL_END = 5,
+  CALL_START = 6,
+  CLASS = 7,
+  COLON = 8,
+  COMMA = 9,
+  COMMENT = 10,
+  CONTINUATION = 11,
+  CONTINUE = 12,
+  DELETE = 13,
+  DO = 14,
+  DOT = 15,
+  DSTRING_START = 16,
+  DSTRING_END = 17,
+  ELSE = 18,
+  EOF = 19,
+  EXISTENCE = 20,
+  FINALLY = 21,
+  FOR = 22,
+  FUNCTION = 23,
+  HERECOMMENT = 24,
+  HEREGEXP_START = 25,
+  HEREGEXP_END = 26,
+  IF = 27,
+  INTERPOLATION_START = 28,
+  INTERPOLATION_END = 29,
+  JS = 30,
+  LBRACE = 31,
+  LBRACKET = 32,
+  LOOP = 33,
+  LPAREN = 34,
+  NEWLINE = 35,
+  NORMAL = 36,
+  NULL = 37,
+  NUMBER = 38,
+  OPERATOR = 39,
+  OWN = 40,
+  PROTO = 41,
+  RANGE = 42,
+  REGEXP = 43,
+  RBRACE = 44,
+  RBRACKET = 45,
+  RELATION = 46,
+  RETURN = 47,
+  RPAREN = 48,
+  SEMICOLON = 49,
+  SPACE = 50,
+  SUPER = 51,
+  SWITCH = 52,
+  SSTRING_START = 53,
+  SSTRING_END = 54,
+  STRING_CONTENT = 55,
+  STRING_LINE_SEPARATOR = 56,
+  STRING_PADDING = 57,
+  TDSTRING_START = 58,
+  TDSTRING_END = 59,
+  THEN = 60,
+  THIS = 61,
+  TRY = 62,
+  TSSTRING_START = 63,
+  TSSTRING_END = 64,
+  UNDEFINED = 65,
+  UNKNOWN = 66,
+  WHEN = 67,
+  WHILE = 68,
+  IDENTIFIER = 69,
+  YIELD = 70,
+  YIELDFROM = 71,
 }
+
+export default SourceType;

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export default function lex(source: string): SourceTokenList {
       ...combinedLocationsForMultiwordOperators(pending, source)
     );
     location = pending.shift();
-    if (previousLocation && previousLocation.type !== SPACE) {
+    if (previousLocation && previousLocation.type !== SourceType.SPACE) {
       tokens.push(
         new SourceToken(
           previousLocation.type,
@@ -39,12 +39,12 @@ export default function lex(source: string): SourceTokenList {
       );
     }
     previousLocation = location;
-  } while (location.type !== EOF);
+  } while (location.type !== SourceType.EOF);
   return new SourceTokenList(tokens);
 }
 
 function combinedLocationsForMultiwordOperators(stream: BufferedStream, source: string): Array<SourceLocation> {
-  if (!stream.hasNext(OPERATOR, SPACE, OPERATOR) && !stream.hasNext(OPERATOR, SPACE, RELATION)) {
+  if (!stream.hasNext(SourceType.OPERATOR, SourceType.SPACE, SourceType.OPERATOR) && !stream.hasNext(SourceType.OPERATOR, SourceType.SPACE, SourceType.RELATION)) {
     return [];
   }
 
@@ -60,7 +60,7 @@ function combinedLocationsForMultiwordOperators(stream: BufferedStream, source: 
       case 'of':
         return [
           new SourceLocation(
-            RELATION,
+            SourceType.RELATION,
             not.index
           )
         ];
@@ -68,7 +68,7 @@ function combinedLocationsForMultiwordOperators(stream: BufferedStream, source: 
       case 'instanceof':
         return [
           new SourceLocation(
-            OPERATOR,
+            SourceType.OPERATOR,
             not.index
           )
         ];
@@ -82,88 +82,18 @@ function combinedLocationsForMultiwordOperators(stream: BufferedStream, source: 
 
 const REGEXP_FLAGS = ['i', 'g', 'm', 'y'];
 
-export const AT = new SourceType('AT');
-export const BOOL = new SourceType('BOOL');
-export const BREAK = new SourceType('BREAK');
-export const CATCH = new SourceType('CATCH');
-export const CALL_END = new SourceType('CALL_END');
-export const CALL_START = new SourceType('CALL_START');
-export const CLASS = new SourceType('CLASS');
-export const COLON = new SourceType('COLON');
-export const COMMA = new SourceType('COMMA');
-export const COMMENT = new SourceType('COMMENT');
-export const CONTINUATION = new SourceType('CONTINUATION');
-export const CONTINUE = new SourceType('CONTINUE');
-export const DELETE = new SourceType('DELETE');
-export const DO = new SourceType('DO');
-export const DOT = new SourceType('DOT');
-export const DSTRING_START = new SourceType('DSTRING_START');
-export const DSTRING_END = new SourceType('DSTRING_END');
-export const ELSE = new SourceType('ELSE');
-export const EOF = new SourceType('EOF');
-export const EXISTENCE = new SourceType('EXISTENCE');
-export const FINALLY = new SourceType('FINALLY');
-export const FOR = new SourceType('FOR');
-export const FUNCTION = new SourceType('FUNCTION');
-export const HERECOMMENT = new SourceType('HERECOMMENT');
-export const HEREGEXP_START = new SourceType('HEREGEXP_START');
-export const HEREGEXP_END = new SourceType('HEREGEXP_END');
-export const IF = new SourceType('IF');
-export const INTERPOLATION_START = new SourceType('INTERPOLATION_START');
-export const INTERPOLATION_END = new SourceType('INTERPOLATION_END');
-export const JS = new SourceType('JS');
-export const LBRACE = new SourceType('LBRACE');
-export const LBRACKET = new SourceType('LBRACKET');
-export const LOOP = new SourceType('LOOP');
-export const LPAREN = new SourceType('LPAREN');
-export const NEWLINE = new SourceType('NEWLINE');
-export const NORMAL = new SourceType('NORMAL');
-export const NULL = new SourceType('NULL');
-export const NUMBER = new SourceType('NUMBER');
-export const OPERATOR = new SourceType('OPERATOR');
-export const OWN = new SourceType('OWN');
-export const PROTO = new SourceType('PROTO');
-export const RANGE = new SourceType('RANGE');
-export const REGEXP = new SourceType('REGEXP');
-export const RBRACE = new SourceType('RBRACE');
-export const RBRACKET = new SourceType('RBRACKET');
-export const RELATION = new SourceType('RELATION');
-export const RETURN = new SourceType('RETURN');
-export const RPAREN = new SourceType('RPAREN');
-export const SEMICOLON = new SourceType('SEMICOLON');
-export const SPACE = new SourceType('SPACE');
-export const SUPER = new SourceType('SUPER');
-export const SWITCH = new SourceType('SWITCH');
-export const SSTRING_START = new SourceType('SSTRING_START');
-export const SSTRING_END = new SourceType('SSTRING_END');
-export const STRING_CONTENT = new SourceType('STRING_CONTENT');
-export const STRING_LINE_SEPARATOR = new SourceType('STRING_LINE_SEPARATOR');
-export const STRING_PADDING = new SourceType('STRING_PADDING');
-export const TDSTRING_START = new SourceType('TDSTRING_START');
-export const TDSTRING_END = new SourceType('TDSTRING_END');
-export const THEN = new SourceType('THEN');
-export const THIS = new SourceType('THIS');
-export const TRY = new SourceType('TRY');
-export const TSSTRING_START = new SourceType('TSSTRING_START');
-export const TSSTRING_END = new SourceType('TSSTRING_END');
-export const UNDEFINED = new SourceType('UNDEFINED');
-export const UNKNOWN = new SourceType('UNKNOWN');
-export const WHEN = new SourceType('WHEN');
-export const WHILE = new SourceType('WHILE');
-export const IDENTIFIER = new SourceType('IDENTIFIER');
-export const YIELD = new SourceType('YIELD');
-export const YIELDFROM = new SourceType('YIELDFROM');
+export { SourceType };
 
 /**
  * Borrowed, with tweaks, from CoffeeScript's lexer.coffee.
  */
-const STRING = [SSTRING_END, DSTRING_END, TSSTRING_END, TDSTRING_END];
+const STRING = [SourceType.SSTRING_END, SourceType.DSTRING_END, SourceType.TSSTRING_END, SourceType.TDSTRING_END];
 const CALLABLE = [
-  IDENTIFIER, CALL_END, RPAREN, RBRACKET, EXISTENCE, AT, THIS, SUPER
+  SourceType.IDENTIFIER, SourceType.CALL_END, SourceType.RPAREN, SourceType.RBRACKET, SourceType.EXISTENCE, SourceType.AT, SourceType.THIS, SourceType.SUPER
 ];
 const INDEXABLE = CALLABLE.concat([
-  NUMBER, ...STRING, REGEXP,
-  BOOL, NULL, UNDEFINED, RBRACE, PROTO
+  SourceType.NUMBER, ...STRING, SourceType.REGEXP,
+  SourceType.BOOL, SourceType.NULL, SourceType.UNDEFINED, SourceType.RBRACE, SourceType.PROTO
 ]);
 const NOT_REGEXP = INDEXABLE; // .concat(['++', '--'])
 
@@ -202,7 +132,7 @@ const OPERATORS = [
  * Provides a stream of source type change locations.
  */
 export function stream(source: string, index: number=0): () => SourceLocation {
-  let location = new SourceLocation(NORMAL, index);
+  let location = new SourceLocation(SourceType.NORMAL, index);
   let interpolationStack: Array<{ type: SourceType, braces: Array<number> }> = [];
   let braceStack: Array<number> = [];
   let parenStack: Array<SourceType> = [];
@@ -220,120 +150,120 @@ export function stream(source: string, index: number=0): () => SourceLocation {
     do {
       start = index;
       if (index >= source.length) {
-        setType(EOF);
+        setType(SourceType.EOF);
       }
 
       switch (location.type) {
-        case NORMAL:
-        case SPACE:
-        case IDENTIFIER:
-        case DOT:
-        case NUMBER:
-        case OPERATOR:
-        case COMMA:
-        case LPAREN:
-        case RPAREN:
-        case CALL_START:
-        case CALL_END:
-        case LBRACE:
-        case RBRACE:
-        case LBRACKET:
-        case RBRACKET:
-        case NEWLINE:
-        case COLON:
-        case FUNCTION:
-        case THIS:
-        case AT:
-        case SEMICOLON:
-        case IF:
-        case ELSE:
-        case THEN:
-        case FOR:
-        case OWN:
-        case WHILE:
-        case BOOL:
-        case NULL:
-        case UNDEFINED:
-        case REGEXP:
-        case SSTRING_END:
-        case DSTRING_END:
-        case TSSTRING_END:
-        case TDSTRING_END:
-        case INTERPOLATION_START:
-        case SUPER:
-        case TRY:
-        case CATCH:
-        case FINALLY:
-        case SWITCH:
-        case WHEN:
-        case BREAK:
-        case CONTINUE:
-        case EXISTENCE:
-        case CLASS:
-        case PROTO:
-        case RANGE:
-        case DELETE:
-        case RETURN:
-        case RELATION:
-        case LOOP:
-        case DO:
-        case YIELD:
-        case YIELDFROM:
-        case CONTINUATION:
+        case SourceType.NORMAL:
+        case SourceType.SPACE:
+        case SourceType.IDENTIFIER:
+        case SourceType.DOT:
+        case SourceType.NUMBER:
+        case SourceType.OPERATOR:
+        case SourceType.COMMA:
+        case SourceType.LPAREN:
+        case SourceType.RPAREN:
+        case SourceType.CALL_START:
+        case SourceType.CALL_END:
+        case SourceType.LBRACE:
+        case SourceType.RBRACE:
+        case SourceType.LBRACKET:
+        case SourceType.RBRACKET:
+        case SourceType.NEWLINE:
+        case SourceType.COLON:
+        case SourceType.FUNCTION:
+        case SourceType.THIS:
+        case SourceType.AT:
+        case SourceType.SEMICOLON:
+        case SourceType.IF:
+        case SourceType.ELSE:
+        case SourceType.THEN:
+        case SourceType.FOR:
+        case SourceType.OWN:
+        case SourceType.WHILE:
+        case SourceType.BOOL:
+        case SourceType.NULL:
+        case SourceType.UNDEFINED:
+        case SourceType.REGEXP:
+        case SourceType.SSTRING_END:
+        case SourceType.DSTRING_END:
+        case SourceType.TSSTRING_END:
+        case SourceType.TDSTRING_END:
+        case SourceType.INTERPOLATION_START:
+        case SourceType.SUPER:
+        case SourceType.TRY:
+        case SourceType.CATCH:
+        case SourceType.FINALLY:
+        case SourceType.SWITCH:
+        case SourceType.WHEN:
+        case SourceType.BREAK:
+        case SourceType.CONTINUE:
+        case SourceType.EXISTENCE:
+        case SourceType.CLASS:
+        case SourceType.PROTO:
+        case SourceType.RANGE:
+        case SourceType.DELETE:
+        case SourceType.RETURN:
+        case SourceType.RELATION:
+        case SourceType.LOOP:
+        case SourceType.DO:
+        case SourceType.YIELD:
+        case SourceType.YIELDFROM:
+        case SourceType.CONTINUATION:
           if (consume(SPACE_PATTERN)) {
-            setType(SPACE);
+            setType(SourceType.SPACE);
           } else if (consume('\n')) {
-            setType(NEWLINE);
+            setType(SourceType.NEWLINE);
           } else if (consume('...') || consume('..')) {
-            setType(RANGE);
+            setType(SourceType.RANGE);
           } else if (consume('.')) {
-            setType(DOT);
+            setType(SourceType.DOT);
           } else if (consume('"""')) {
             stringStack.push({
               allowInterpolations: true,
               endingDelimiter: '"""',
-              endSourceType: TDSTRING_END,
+              endSourceType: SourceType.TDSTRING_END,
             });
-            setType(TDSTRING_START);
+            setType(SourceType.TDSTRING_START);
           } else if (consume('"')) {
             stringStack.push({
               allowInterpolations: true,
               endingDelimiter: '"',
-              endSourceType: DSTRING_END,
+              endSourceType: SourceType.DSTRING_END,
             });
-            setType(DSTRING_START);
+            setType(SourceType.DSTRING_START);
           } else if (consume('\'\'\'')) {
             stringStack.push({
               allowInterpolations: false,
               endingDelimiter: '\'\'\'',
-              endSourceType: TSSTRING_END,
+              endSourceType: SourceType.TSSTRING_END,
             });
-            setType(TSSTRING_START);
+            setType(SourceType.TSSTRING_START);
           } else if (consume('\'')) {
             stringStack.push({
               allowInterpolations: false,
               endingDelimiter: '\'',
-              endSourceType: SSTRING_END,
+              endSourceType: SourceType.SSTRING_END,
             });
-            setType(SSTRING_START);
+            setType(SourceType.SSTRING_START);
           } else if (consume(/^###[^#]/)) {
-            setType(HERECOMMENT);
+            setType(SourceType.HERECOMMENT);
           } else if (consume('#')) {
-            setType(COMMENT);
+            setType(SourceType.COMMENT);
           } else if (consume('///')) {
             stringStack.push({
               allowInterpolations: true,
               endingDelimiter: '///',
-              endSourceType: HEREGEXP_END,
+              endSourceType: SourceType.HEREGEXP_END,
             });
-            setType(HEREGEXP_START);
+            setType(SourceType.HEREGEXP_START);
           } else if (consume('(')) {
             if (CALLABLE.indexOf(location.type) >= 0) {
-              parenStack.push(CALL_START);
-              setType(CALL_START);
+              parenStack.push(SourceType.CALL_START);
+              setType(SourceType.CALL_START);
             } else {
-              parenStack.push(LPAREN);
-              setType(LPAREN);
+              parenStack.push(SourceType.LPAREN);
+              setType(SourceType.LPAREN);
             }
           } else if (consume(')')) {
             if (parenStack.length === 0) {
@@ -341,12 +271,12 @@ export function stream(source: string, index: number=0): () => SourceLocation {
             } else {
               let lparen = parenStack.pop();
               switch (lparen) {
-                case LPAREN:
-                  setType(RPAREN);
+                case SourceType.LPAREN:
+                  setType(SourceType.RPAREN);
                   break;
 
-                case CALL_START:
-                  setType(CALL_END);
+                case SourceType.CALL_START:
+                  setType(SourceType.CALL_END);
                   break;
 
                 default:
@@ -356,109 +286,109 @@ export function stream(source: string, index: number=0): () => SourceLocation {
               }
             }
           } else if (consume('[')) {
-            setType(LBRACKET);
+            setType(SourceType.LBRACKET);
           } else if (consume(']')) {
-            setType(RBRACKET);
+            setType(SourceType.RBRACKET);
           } else if (consume('{')) {
             braceStack.push(start);
-            setType(LBRACE);
+            setType(SourceType.LBRACE);
           } else if (consume('}')) {
             if (braceStack.length === 0) {
               popInterpolation();
             } else {
               braceStack.pop();
-              setType(RBRACE);
+              setType(SourceType.RBRACE);
             }
           } else if (consumeAny(['->', '=>'])) {
-            setType(FUNCTION);
+            setType(SourceType.FUNCTION);
           } else if (consumeRegexp()) {
-            setType(REGEXP);
+            setType(SourceType.REGEXP);
           } else if (consume('::')) {
-            setType(PROTO);
+            setType(SourceType.PROTO);
           } else if (consume(':')) {
-            setType(COLON);
+            setType(SourceType.COLON);
           } else if (consume(',')) {
-            setType(COMMA);
+            setType(SourceType.COMMA);
           } else if (consume('@')) {
-            setType(AT);
+            setType(SourceType.AT);
           } else if (consume(';')) {
-            setType(SEMICOLON);
+            setType(SourceType.SEMICOLON);
           } else if (consume('`')) {
-            setType(JS);
+            setType(SourceType.JS);
           } else if (consumeAny(OPERATORS)) {
             if (consumed() === '?') {
-              setType(EXISTENCE);
+              setType(SourceType.EXISTENCE);
             } else {
-              setType(OPERATOR);
+              setType(SourceType.OPERATOR);
             }
           } else if (consume(YIELDFROM_PATTERN)) {
-            setType(YIELDFROM);
+            setType(SourceType.YIELDFROM);
           } else if (consume(IDENTIFIER_PATTERN)) {
             let prevLocationIndex = locations.length - 1;
-            while (prevLocationIndex > 0 && locations[prevLocationIndex].type === NEWLINE) {
+            while (prevLocationIndex > 0 && locations[prevLocationIndex].type === SourceType.NEWLINE) {
               prevLocationIndex--;
             }
             let prev = locations[prevLocationIndex];
-            if (prev && (prev.type === DOT || prev.type === PROTO || prev.type === AT)) {
-              setType(IDENTIFIER);
+            if (prev && (prev.type === SourceType.DOT || prev.type === SourceType.PROTO || prev.type === SourceType.AT)) {
+              setType(SourceType.IDENTIFIER);
             } else {
               switch (consumed()) {
                 case 'if':
                 case 'unless':
-                  setType(IF);
+                  setType(SourceType.IF);
                   break;
 
                 case 'else':
-                  setType(ELSE);
+                  setType(SourceType.ELSE);
                   break;
 
                 case 'return':
-                  setType(RETURN);
+                  setType(SourceType.RETURN);
                   break;
 
                 case 'for':
-                  setType(FOR);
+                  setType(SourceType.FOR);
                   break;
 
                 case 'own':
-                  setType(OWN);
+                  setType(SourceType.OWN);
                   break;
 
                 case 'while':
                 case 'until':
-                  setType(WHILE);
+                  setType(SourceType.WHILE);
                   break;
 
                 case 'loop':
-                  setType(LOOP);
+                  setType(SourceType.LOOP);
                   break;
 
                 case 'then':
-                  setType(THEN);
+                  setType(SourceType.THEN);
                   break;
 
                 case 'switch':
-                  setType(SWITCH);
+                  setType(SourceType.SWITCH);
                   break;
 
                 case 'when':
-                  setType(WHEN);
+                  setType(SourceType.WHEN);
                   break;
 
                 case 'null':
-                  setType(NULL);
+                  setType(SourceType.NULL);
                   break;
 
                 case 'undefined':
-                  setType(UNDEFINED);
+                  setType(SourceType.UNDEFINED);
                   break;
 
                 case 'this':
-                  setType(THIS);
+                  setType(SourceType.THIS);
                   break;
 
                 case 'super':
-                  setType(SUPER);
+                  setType(SourceType.SUPER);
                   break;
 
                 case 'true':
@@ -467,7 +397,7 @@ export function stream(source: string, index: number=0): () => SourceLocation {
                 case 'no':
                 case 'on':
                 case 'off':
-                  setType(BOOL);
+                  setType(SourceType.BOOL);
                   break;
 
                 case 'and':
@@ -476,72 +406,72 @@ export function stream(source: string, index: number=0): () => SourceLocation {
                 case 'is':
                 case 'isnt':
                 case 'instanceof':
-                  setType(OPERATOR);
+                  setType(SourceType.OPERATOR);
                   break;
 
                 case 'class':
-                  setType(CLASS);
+                  setType(SourceType.CLASS);
                   break;
 
                 case 'break':
-                  setType(BREAK);
+                  setType(SourceType.BREAK);
                   break;
 
                 case 'continue':
-                  setType(CONTINUE);
+                  setType(SourceType.CONTINUE);
                   break;
 
                 case 'try':
-                  setType(TRY);
+                  setType(SourceType.TRY);
                   break;
 
                 case 'catch':
-                  setType(CATCH);
+                  setType(SourceType.CATCH);
                   break;
 
                 case 'finally':
-                  setType(FINALLY);
+                  setType(SourceType.FINALLY);
                   break;
 
                 case 'delete':
-                  setType(DELETE);
+                  setType(SourceType.DELETE);
                   break;
 
                 case 'in':
                 case 'of':
-                  setType(RELATION);
+                  setType(SourceType.RELATION);
                   break;
 
                 case 'do':
-                  setType(DO);
+                  setType(SourceType.DO);
                   break;
 
                 case 'yield':
-                  setType(YIELD);
+                  setType(SourceType.YIELD);
                   break;
 
                 default:
-                  setType(IDENTIFIER);
+                  setType(SourceType.IDENTIFIER);
               }
             }
           } else if (consume(NUMBER_PATTERN)) {
-            setType(NUMBER);
+            setType(SourceType.NUMBER);
           } else if (consume('\\')) {
-            setType(CONTINUATION);
+            setType(SourceType.CONTINUATION);
           } else {
-            setType(UNKNOWN);
+            setType(SourceType.UNKNOWN);
           }
           break;
 
-        case SSTRING_START:
-        case DSTRING_START:
-        case TSSTRING_START:
-        case TDSTRING_START:
-        case HEREGEXP_START:
-          setType(STRING_CONTENT);
+        case SourceType.SSTRING_START:
+        case SourceType.DSTRING_START:
+        case SourceType.TSSTRING_START:
+        case SourceType.TDSTRING_START:
+        case SourceType.HEREGEXP_START:
+          setType(SourceType.STRING_CONTENT);
           break;
 
-        case STRING_CONTENT: {
+        case SourceType.STRING_CONTENT: {
           let stringOptions = stringStack[stringStack.length - 1];
           if (!stringOptions) {
             throw new Error(
@@ -560,23 +490,23 @@ export function stream(source: string, index: number=0): () => SourceLocation {
           break;
         }
 
-        case COMMENT:
+        case SourceType.COMMENT:
           if (consume('\n')) {
-            setType(NEWLINE);
+            setType(SourceType.NEWLINE);
           } else {
             index++;
           }
           break;
 
-        case HERECOMMENT:
+        case SourceType.HERECOMMENT:
           if (consume('###')) {
-            setType(NORMAL);
+            setType(SourceType.NORMAL);
           } else {
             index++;
           }
           break;
 
-        case INTERPOLATION_END:
+        case SourceType.INTERPOLATION_END:
           let lastInterpolation = interpolationStack.pop();
           if (!lastInterpolation) {
             throw new Error(`found interpolation end without any interpolation start`);
@@ -586,24 +516,24 @@ export function stream(source: string, index: number=0): () => SourceLocation {
           braceStack = braces;
           break;
 
-        case HEREGEXP_END:
+        case SourceType.HEREGEXP_END:
           while (consumeAny(REGEXP_FLAGS)) {
             // condition has side-effect
           }
-          setType(NORMAL);
+          setType(SourceType.NORMAL);
           break;
 
-        case JS:
+        case SourceType.JS:
           if (consume('\\')) {
             index++;
           } else if (consume('`')) {
-            setType(NORMAL);
+            setType(SourceType.NORMAL);
           } else {
             index++;
           }
           break;
 
-        case EOF:
+        case SourceType.EOF:
           if (braceStack.length !== 0) {
             throw new Error(
               `unexpected EOF while looking for '}' to match '{' ` +
@@ -615,22 +545,22 @@ export function stream(source: string, index: number=0): () => SourceLocation {
           }
           break;
 
-        case UNKNOWN:
+        case SourceType.UNKNOWN:
           // Jump to the end.
           index = source.length;
           break;
 
         default:
-          throw new Error(`unknown source type at offset ${location.index}: ${location.type.name}`);
+          throw new Error(`unknown source type at offset ${location.index}: ${SourceType[location.type]}`);
       }
 
       shouldStepAgain = (
         // Don't report on going back to "normal" source code.
-        location.type === NORMAL ||
+        location.type === SourceType.NORMAL ||
         // Don't report if nothing has changed, unless we're at the end.
         (
           location === lastLocation &&
-          location.type !== EOF
+          location.type !== SourceType.EOF
         )
       );
     } while (shouldStepAgain);
@@ -662,7 +592,7 @@ export function stream(source: string, index: number=0): () => SourceLocation {
     let prev = locations[locations.length - 1];
     if (prev) {
       let spaced = false;
-      if (prev.type === SPACE) {
+      if (prev.type === SourceType.SPACE) {
         spaced = true;
         prev = locations[locations.length - 2];
       }
@@ -700,7 +630,7 @@ export function stream(source: string, index: number=0): () => SourceLocation {
 
   function pushInterpolation() {
     interpolationStack.push({ type: location.type, braces: braceStack });
-    setType(INTERPOLATION_START);
+    setType(SourceType.INTERPOLATION_START);
     braceStack = [];
   }
 
@@ -708,7 +638,7 @@ export function stream(source: string, index: number=0): () => SourceLocation {
     if (interpolationStack.length === 0) {
       throw new Error(`unexpected '}' found in string at ${index}: ${JSON.stringify(source)}`);
     }
-    setType(INTERPOLATION_END);
+    setType(SourceType.INTERPOLATION_END);
   }
 }
 
@@ -718,6 +648,6 @@ export function consumeStream(lexer: () => SourceLocation): Array<SourceLocation
   do {
     location = lexer();
     result.push(location);
-  } while (location.type !== EOF);
+  } while (location.type !== SourceType.EOF);
   return result;
 }

--- a/src/utils/PaddingTracker.ts
+++ b/src/utils/PaddingTracker.ts
@@ -1,12 +1,4 @@
-import {
-  INTERPOLATION_END,
-  INTERPOLATION_START,
-  STRING_CONTENT,
-  STRING_LINE_SEPARATOR,
-  STRING_PADDING
-} from '../index';
 import SourceLocation from '../SourceLocation';
-
 import SourceType from '../SourceType';
 import BufferedStream from './BufferedStream';
 
@@ -44,15 +36,15 @@ export default class PaddingTracker {
     do {
       location = stream.shift();
       this._originalLocations.push(location);
-      if (interpolationLevel === 0 && location.type === STRING_CONTENT) {
+      if (interpolationLevel === 0 && location.type === SourceType.STRING_CONTENT) {
         let start = location.index;
         let end = stream.peek().index;
         let content = source.slice(start, end);
         let index = this.fragments.length;
         this.fragments.push(new TrackedFragment(content, start, end, index));
-      } else if (location.type === INTERPOLATION_START) {
+      } else if (location.type === SourceType.INTERPOLATION_START) {
         interpolationLevel += 1;
-      } else if (location.type === INTERPOLATION_END) {
+      } else if (location.type === SourceType.INTERPOLATION_END) {
         interpolationLevel -= 1;
       }
     } while (interpolationLevel > 0 || location.type !== endType);
@@ -63,7 +55,7 @@ export default class PaddingTracker {
     let rangeIndex = 0;
     for (let location of this._originalLocations) {
       let currentRange = this.fragments[rangeIndex];
-      if (location.type === STRING_CONTENT &&
+      if (location.type === SourceType.STRING_CONTENT &&
           currentRange && location.index === currentRange.start) {
         resultLocations.push(...currentRange.computeSourceLocations());
         rangeIndex++;
@@ -108,7 +100,7 @@ export class TrackedFragment {
 
   computeSourceLocations(): Array<SourceLocation> {
     if (this.start === this.end) {
-      return [new SourceLocation(STRING_CONTENT, this.start)];
+      return [new SourceLocation(SourceType.STRING_CONTENT, this.start)];
     }
 
     // Break the marked ranges down into events, similar to how you might count
@@ -150,11 +142,11 @@ export class TrackedFragment {
 
       let sourceType;
       if (paddingDepth > 0) {
-        sourceType = STRING_PADDING;
+        sourceType = SourceType.STRING_PADDING;
       } else if (lineSeparatorDepth > 0) {
-        sourceType = STRING_LINE_SEPARATOR;
+        sourceType = SourceType.STRING_LINE_SEPARATOR;
       } else {
-        sourceType = STRING_CONTENT;
+        sourceType = SourceType.STRING_CONTENT;
       }
       if (sourceType !== lastSourceType) {
         resultLocations.push(new SourceLocation(sourceType, sourceIndex));

--- a/src/utils/calculateHeregexpPadding.ts
+++ b/src/utils/calculateHeregexpPadding.ts
@@ -1,4 +1,4 @@
-import { HEREGEXP_END, HEREGEXP_START } from '../index';
+import SourceType from '../SourceType';
 import PaddingTracker from './PaddingTracker';
 
 import SourceLocation from '../SourceLocation';
@@ -9,10 +9,10 @@ import BufferedStream from './BufferedStream';
  * characters are removed, and comments are respected.
  */
 export default function calculateHeregexpPadding(source: string, stream: BufferedStream): Array<SourceLocation> {
-  if (!stream.hasNext(HEREGEXP_START)) {
+  if (!stream.hasNext(SourceType.HEREGEXP_START)) {
     return [];
   }
-  let paddingTracker = new PaddingTracker(source, stream, HEREGEXP_END);
+  let paddingTracker = new PaddingTracker(source, stream, SourceType.HEREGEXP_END);
 
   for (let fragment of paddingTracker.fragments) {
     let content = fragment.content;

--- a/src/utils/calculateNormalStringPadding.ts
+++ b/src/utils/calculateNormalStringPadding.ts
@@ -1,4 +1,4 @@
-import { DSTRING_END, DSTRING_START, SSTRING_END, SSTRING_START } from '../index';
+import SourceType from '../SourceType';
 import PaddingTracker from './PaddingTracker';
 
 import SourceLocation from '../SourceLocation';
@@ -14,10 +14,10 @@ import BufferedStream from './BufferedStream';
  */
 export default function calculateNormalStringPadding(source: string, stream: BufferedStream): Array<SourceLocation> {
   let paddingTracker;
-  if (stream.hasNext(SSTRING_START)) {
-    paddingTracker = new PaddingTracker(source, stream, SSTRING_END);
-  } else if (stream.hasNext(DSTRING_START)) {
-    paddingTracker = new PaddingTracker(source, stream, DSTRING_END);
+  if (stream.hasNext(SourceType.SSTRING_START)) {
+    paddingTracker = new PaddingTracker(source, stream, SourceType.SSTRING_END);
+  } else if (stream.hasNext(SourceType.DSTRING_START)) {
+    paddingTracker = new PaddingTracker(source, stream, SourceType.DSTRING_END);
   } else {
     return [];
   }

--- a/src/utils/calculateTripleQuotedStringPadding.ts
+++ b/src/utils/calculateTripleQuotedStringPadding.ts
@@ -1,10 +1,5 @@
-import {
-  TDSTRING_END,
-  TDSTRING_START,
-  TSSTRING_END,
-  TSSTRING_START,
-} from '../index';
 import SourceLocation from '../SourceLocation';
+import SourceType from '../SourceType';
 import BufferedStream from './BufferedStream';
 import PaddingTracker from './PaddingTracker';
 import { TrackedFragment } from './PaddingTracker';
@@ -35,10 +30,10 @@ import { TrackedFragment } from './PaddingTracker';
  */
 export default function calculateTripleQuotedStringPadding(source: string, stream: BufferedStream): Array<SourceLocation> {
   let paddingTracker;
-  if (stream.hasNext(TSSTRING_START)) {
-    paddingTracker = new PaddingTracker(source, stream, TSSTRING_END);
-  } else if (stream.hasNext(TDSTRING_START)) {
-    paddingTracker = new PaddingTracker(source, stream, TDSTRING_END);
+  if (stream.hasNext(SourceType.TSSTRING_START)) {
+    paddingTracker = new PaddingTracker(source, stream, SourceType.TSSTRING_END);
+  } else if (stream.hasNext(SourceType.TDSTRING_START)) {
+    paddingTracker = new PaddingTracker(source, stream, SourceType.TDSTRING_END);
   } else {
     return [];
   }

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,78 +1,6 @@
 import { deepEqual, ok, strictEqual } from 'assert';
 import { inspect } from 'util';
-import lex, {
-  consumeStream,
-  stream,
-  AT,
-  BOOL,
-  BREAK,
-  CALL_END,
-  CALL_START,
-  CATCH,
-  CLASS,
-  COLON,
-  COMMA,
-  COMMENT,
-  CONTINUATION,
-  CONTINUE,
-  DELETE,
-  DO,
-  DOT,
-  DSTRING_END,
-  DSTRING_START,
-  ELSE,
-  EOF,
-  EXISTENCE,
-  FINALLY,
-  FOR,
-  FUNCTION,
-  HERECOMMENT,
-  HEREGEXP_END,
-  HEREGEXP_START,
-  IDENTIFIER,
-  IF,
-  INTERPOLATION_END,
-  INTERPOLATION_START,
-  JS,
-  LBRACE,
-  LBRACKET,
-  LOOP,
-  LPAREN,
-  NEWLINE,
-  NULL,
-  NUMBER,
-  OPERATOR,
-  OWN,
-  PROTO,
-  RANGE,
-  RBRACE,
-  RBRACKET,
-  REGEXP,
-  RELATION,
-  RETURN,
-  RPAREN,
-  SEMICOLON,
-  SPACE,
-  SSTRING_END,
-  SSTRING_START,
-  STRING_CONTENT,
-  STRING_LINE_SEPARATOR,
-  STRING_PADDING,
-  SUPER,
-  SWITCH,
-  TDSTRING_END,
-  TDSTRING_START,
-  THEN,
-  THIS,
-  TRY,
-  TSSTRING_END,
-  TSSTRING_START,
-  UNDEFINED,
-  WHEN,
-  WHILE,
-  YIELD,
-  YIELDFROM,
-} from '../src/index';
+import lex, { consumeStream, stream, SourceType } from '../src/index';
 import SourceLocation from '../src/SourceLocation';
 import SourceToken from '../src/SourceToken';
 import SourceTokenList from '../src/SourceTokenList';
@@ -91,9 +19,9 @@ describe('lexTest', () => {
     deepEqual(
       lex(`a + b`).toArray(),
       [
-        new SourceToken(IDENTIFIER, 0, 1),
-        new SourceToken(OPERATOR, 2, 3),
-        new SourceToken(IDENTIFIER, 4, 5)
+        new SourceToken(SourceType.IDENTIFIER, 0, 1),
+        new SourceToken(SourceType.OPERATOR, 2, 3),
+        new SourceToken(SourceType.IDENTIFIER, 4, 5)
       ]
     );
   });
@@ -106,17 +34,17 @@ describe('lexTest', () => {
     deepEqual(
       lex(`"b#{c}d#{e}f"`).toArray(),
       [
-        new SourceToken(DSTRING_START, 0, 1),
-        new SourceToken(STRING_CONTENT, 1, 2),
-        new SourceToken(INTERPOLATION_START, 2, 4),
-        new SourceToken(IDENTIFIER, 4, 5),
-        new SourceToken(INTERPOLATION_END, 5, 6),
-        new SourceToken(STRING_CONTENT, 6, 7),
-        new SourceToken(INTERPOLATION_START, 7, 9),
-        new SourceToken(IDENTIFIER, 9, 10),
-        new SourceToken(INTERPOLATION_END, 10, 11),
-        new SourceToken(STRING_CONTENT, 11, 12),
-        new SourceToken(DSTRING_END, 12, 13)
+        new SourceToken(SourceType.DSTRING_START, 0, 1),
+        new SourceToken(SourceType.STRING_CONTENT, 1, 2),
+        new SourceToken(SourceType.INTERPOLATION_START, 2, 4),
+        new SourceToken(SourceType.IDENTIFIER, 4, 5),
+        new SourceToken(SourceType.INTERPOLATION_END, 5, 6),
+        new SourceToken(SourceType.STRING_CONTENT, 6, 7),
+        new SourceToken(SourceType.INTERPOLATION_START, 7, 9),
+        new SourceToken(SourceType.IDENTIFIER, 9, 10),
+        new SourceToken(SourceType.INTERPOLATION_END, 10, 11),
+        new SourceToken(SourceType.STRING_CONTENT, 11, 12),
+        new SourceToken(SourceType.DSTRING_END, 12, 13)
       ]
     );
   });
@@ -125,23 +53,23 @@ describe('lexTest', () => {
     deepEqual(
       lex(`"  b#{c}  \n  d#{e}  \n  f  "`).toArray(),
       [
-        new SourceToken(DSTRING_START, 0, 1),
-        new SourceToken(STRING_CONTENT, 1, 4),
-        new SourceToken(INTERPOLATION_START, 4, 6),
-        new SourceToken(IDENTIFIER, 6, 7),
-        new SourceToken(INTERPOLATION_END, 7, 8),
-        new SourceToken(STRING_PADDING, 8, 10),
-        new SourceToken(STRING_LINE_SEPARATOR, 10, 11),
-        new SourceToken(STRING_PADDING, 11, 13),
-        new SourceToken(STRING_CONTENT, 13, 14),
-        new SourceToken(INTERPOLATION_START, 14, 16),
-        new SourceToken(IDENTIFIER, 16, 17),
-        new SourceToken(INTERPOLATION_END, 17, 18),
-        new SourceToken(STRING_PADDING, 18, 20),
-        new SourceToken(STRING_LINE_SEPARATOR, 20, 21),
-        new SourceToken(STRING_PADDING, 21, 23),
-        new SourceToken(STRING_CONTENT, 23, 26),
-        new SourceToken(DSTRING_END, 26, 27)
+        new SourceToken(SourceType.DSTRING_START, 0, 1),
+        new SourceToken(SourceType.STRING_CONTENT, 1, 4),
+        new SourceToken(SourceType.INTERPOLATION_START, 4, 6),
+        new SourceToken(SourceType.IDENTIFIER, 6, 7),
+        new SourceToken(SourceType.INTERPOLATION_END, 7, 8),
+        new SourceToken(SourceType.STRING_PADDING, 8, 10),
+        new SourceToken(SourceType.STRING_LINE_SEPARATOR, 10, 11),
+        new SourceToken(SourceType.STRING_PADDING, 11, 13),
+        new SourceToken(SourceType.STRING_CONTENT, 13, 14),
+        new SourceToken(SourceType.INTERPOLATION_START, 14, 16),
+        new SourceToken(SourceType.IDENTIFIER, 16, 17),
+        new SourceToken(SourceType.INTERPOLATION_END, 17, 18),
+        new SourceToken(SourceType.STRING_PADDING, 18, 20),
+        new SourceToken(SourceType.STRING_LINE_SEPARATOR, 20, 21),
+        new SourceToken(SourceType.STRING_PADDING, 21, 23),
+        new SourceToken(SourceType.STRING_CONTENT, 23, 26),
+        new SourceToken(SourceType.DSTRING_END, 26, 27)
       ]
     );
   });
@@ -150,17 +78,17 @@ describe('lexTest', () => {
     deepEqual(
       lex(`"#{a}#{b}"`).toArray(),
       [
-        new SourceToken(DSTRING_START, 0, 1),
-        new SourceToken(STRING_CONTENT, 1, 1),
-        new SourceToken(INTERPOLATION_START, 1, 3),
-        new SourceToken(IDENTIFIER, 3, 4),
-        new SourceToken(INTERPOLATION_END, 4, 5),
-        new SourceToken(STRING_CONTENT, 5, 5),
-        new SourceToken(INTERPOLATION_START, 5, 7),
-        new SourceToken(IDENTIFIER, 7, 8),
-        new SourceToken(INTERPOLATION_END, 8, 9),
-        new SourceToken(STRING_CONTENT, 9, 9),
-        new SourceToken(DSTRING_END, 9, 10)
+        new SourceToken(SourceType.DSTRING_START, 0, 1),
+        new SourceToken(SourceType.STRING_CONTENT, 1, 1),
+        new SourceToken(SourceType.INTERPOLATION_START, 1, 3),
+        new SourceToken(SourceType.IDENTIFIER, 3, 4),
+        new SourceToken(SourceType.INTERPOLATION_END, 4, 5),
+        new SourceToken(SourceType.STRING_CONTENT, 5, 5),
+        new SourceToken(SourceType.INTERPOLATION_START, 5, 7),
+        new SourceToken(SourceType.IDENTIFIER, 7, 8),
+        new SourceToken(SourceType.INTERPOLATION_END, 8, 9),
+        new SourceToken(SourceType.STRING_CONTENT, 9, 9),
+        new SourceToken(SourceType.DSTRING_END, 9, 10)
       ]
     );
   });
@@ -169,21 +97,21 @@ describe('lexTest', () => {
     deepEqual(
       lex(`"""\n  b#{c}\n  d#{e}f\n"""`).toArray(),
       [
-        new SourceToken(TDSTRING_START, 0, 3),
-        new SourceToken(STRING_PADDING, 3, 6),
-        new SourceToken(STRING_CONTENT, 6, 7),
-        new SourceToken(INTERPOLATION_START, 7, 9),
-        new SourceToken(IDENTIFIER, 9, 10),
-        new SourceToken(INTERPOLATION_END, 10, 11),
-        new SourceToken(STRING_CONTENT, 11, 12),
-        new SourceToken(STRING_PADDING, 12, 14),
-        new SourceToken(STRING_CONTENT, 14, 15),
-        new SourceToken(INTERPOLATION_START, 15, 17),
-        new SourceToken(IDENTIFIER, 17, 18),
-        new SourceToken(INTERPOLATION_END, 18, 19),
-        new SourceToken(STRING_CONTENT, 19, 20),
-        new SourceToken(STRING_PADDING, 20, 21),
-        new SourceToken(TDSTRING_END, 21, 24)
+        new SourceToken(SourceType.TDSTRING_START, 0, 3),
+        new SourceToken(SourceType.STRING_PADDING, 3, 6),
+        new SourceToken(SourceType.STRING_CONTENT, 6, 7),
+        new SourceToken(SourceType.INTERPOLATION_START, 7, 9),
+        new SourceToken(SourceType.IDENTIFIER, 9, 10),
+        new SourceToken(SourceType.INTERPOLATION_END, 10, 11),
+        new SourceToken(SourceType.STRING_CONTENT, 11, 12),
+        new SourceToken(SourceType.STRING_PADDING, 12, 14),
+        new SourceToken(SourceType.STRING_CONTENT, 14, 15),
+        new SourceToken(SourceType.INTERPOLATION_START, 15, 17),
+        new SourceToken(SourceType.IDENTIFIER, 17, 18),
+        new SourceToken(SourceType.INTERPOLATION_END, 18, 19),
+        new SourceToken(SourceType.STRING_CONTENT, 19, 20),
+        new SourceToken(SourceType.STRING_PADDING, 20, 21),
+        new SourceToken(SourceType.TDSTRING_END, 21, 24)
       ]
     );
   });
@@ -192,13 +120,13 @@ describe('lexTest', () => {
     deepEqual(
       lex(`"""\n#{a}\n"""`).toArray(),
       [
-        new SourceToken(TDSTRING_START, 0, 3),
-        new SourceToken(STRING_PADDING, 3, 4),
-        new SourceToken(INTERPOLATION_START, 4, 6),
-        new SourceToken(IDENTIFIER, 6, 7),
-        new SourceToken(INTERPOLATION_END, 7, 8),
-        new SourceToken(STRING_PADDING, 8, 9),
-        new SourceToken(TDSTRING_END, 9, 12)
+        new SourceToken(SourceType.TDSTRING_START, 0, 3),
+        new SourceToken(SourceType.STRING_PADDING, 3, 4),
+        new SourceToken(SourceType.INTERPOLATION_START, 4, 6),
+        new SourceToken(SourceType.IDENTIFIER, 6, 7),
+        new SourceToken(SourceType.INTERPOLATION_END, 7, 8),
+        new SourceToken(SourceType.STRING_PADDING, 8, 9),
+        new SourceToken(SourceType.TDSTRING_END, 9, 12)
       ]
     );
   });
@@ -207,19 +135,19 @@ describe('lexTest', () => {
     deepEqual(
       lex(`"#{"#{a}"}"`).toArray(),
       [
-        new SourceToken(DSTRING_START, 0, 1),
-        new SourceToken(STRING_CONTENT, 1, 1),
-        new SourceToken(INTERPOLATION_START, 1, 3),
-        new SourceToken(DSTRING_START, 3, 4),
-        new SourceToken(STRING_CONTENT, 4, 4),
-        new SourceToken(INTERPOLATION_START, 4, 6),
-        new SourceToken(IDENTIFIER, 6, 7),
-        new SourceToken(INTERPOLATION_END, 7, 8),
-        new SourceToken(STRING_CONTENT, 8, 8),
-        new SourceToken(DSTRING_END, 8, 9),
-        new SourceToken(INTERPOLATION_END, 9, 10),
-        new SourceToken(STRING_CONTENT, 10, 10),
-        new SourceToken(DSTRING_END, 10, 11)
+        new SourceToken(SourceType.DSTRING_START, 0, 1),
+        new SourceToken(SourceType.STRING_CONTENT, 1, 1),
+        new SourceToken(SourceType.INTERPOLATION_START, 1, 3),
+        new SourceToken(SourceType.DSTRING_START, 3, 4),
+        new SourceToken(SourceType.STRING_CONTENT, 4, 4),
+        new SourceToken(SourceType.INTERPOLATION_START, 4, 6),
+        new SourceToken(SourceType.IDENTIFIER, 6, 7),
+        new SourceToken(SourceType.INTERPOLATION_END, 7, 8),
+        new SourceToken(SourceType.STRING_CONTENT, 8, 8),
+        new SourceToken(SourceType.DSTRING_END, 8, 9),
+        new SourceToken(SourceType.INTERPOLATION_END, 9, 10),
+        new SourceToken(SourceType.STRING_CONTENT, 10, 10),
+        new SourceToken(SourceType.DSTRING_END, 10, 11)
       ]
     );
   });
@@ -228,13 +156,13 @@ describe('lexTest', () => {
     deepEqual(
       lex(`"#{ a }"`).toArray(),
       [
-        new SourceToken(DSTRING_START, 0, 1),
-        new SourceToken(STRING_CONTENT, 1, 1),
-        new SourceToken(INTERPOLATION_START, 1, 3),
-        new SourceToken(IDENTIFIER, 4, 5),
-        new SourceToken(INTERPOLATION_END, 6, 7),
-        new SourceToken(STRING_CONTENT, 7, 7),
-        new SourceToken(DSTRING_END, 7, 8)
+        new SourceToken(SourceType.DSTRING_START, 0, 1),
+        new SourceToken(SourceType.STRING_CONTENT, 1, 1),
+        new SourceToken(SourceType.INTERPOLATION_START, 1, 3),
+        new SourceToken(SourceType.IDENTIFIER, 4, 5),
+        new SourceToken(SourceType.INTERPOLATION_END, 6, 7),
+        new SourceToken(SourceType.STRING_CONTENT, 7, 7),
+        new SourceToken(SourceType.DSTRING_END, 7, 8)
       ]
     );
   });
@@ -243,9 +171,9 @@ describe('lexTest', () => {
     deepEqual(
       lex('a not instanceof b').toArray(),
       [
-        new SourceToken(IDENTIFIER, 0, 1),
-        new SourceToken(OPERATOR, 2, 16),
-        new SourceToken(IDENTIFIER, 17, 18)
+        new SourceToken(SourceType.IDENTIFIER, 0, 1),
+        new SourceToken(SourceType.OPERATOR, 2, 16),
+        new SourceToken(SourceType.IDENTIFIER, 17, 18)
       ]
     );
   });
@@ -254,9 +182,9 @@ describe('lexTest', () => {
     deepEqual(
       lex('a not in b').toArray(),
       [
-        new SourceToken(IDENTIFIER, 0, 1),
-        new SourceToken(RELATION, 2, 8),
-        new SourceToken(IDENTIFIER, 9, 10)
+        new SourceToken(SourceType.IDENTIFIER, 0, 1),
+        new SourceToken(SourceType.RELATION, 2, 8),
+        new SourceToken(SourceType.IDENTIFIER, 9, 10)
       ]
     );
   });
@@ -265,9 +193,9 @@ describe('lexTest', () => {
     deepEqual(
       lex('a not of b').toArray(),
       [
-        new SourceToken(IDENTIFIER, 0, 1),
-        new SourceToken(RELATION, 2, 8),
-        new SourceToken(IDENTIFIER, 9, 10)
+        new SourceToken(SourceType.IDENTIFIER, 0, 1),
+        new SourceToken(SourceType.RELATION, 2, 8),
+        new SourceToken(SourceType.IDENTIFIER, 9, 10)
       ]
     );
   });
@@ -276,32 +204,32 @@ describe('lexTest', () => {
     deepEqual(
       lex('a(super(@(b[0](), true&(false), b?())))').toArray(),
       [
-        new SourceToken(IDENTIFIER, 0, 1),
-        new SourceToken(CALL_START, 1, 2),
-        new SourceToken(SUPER, 2, 7),
-        new SourceToken(CALL_START, 7, 8),
-        new SourceToken(AT, 8, 9),
-        new SourceToken(CALL_START, 9, 10),
-        new SourceToken(IDENTIFIER, 10, 11),
-        new SourceToken(LBRACKET, 11, 12),
-        new SourceToken(NUMBER, 12, 13),
-        new SourceToken(RBRACKET, 13, 14),
-        new SourceToken(CALL_START, 14, 15),
-        new SourceToken(CALL_END, 15, 16),
-        new SourceToken(COMMA, 16, 17),
-        new SourceToken(BOOL, 18, 22),
-        new SourceToken(OPERATOR, 22, 23),
-        new SourceToken(LPAREN, 23, 24),
-        new SourceToken(BOOL, 24, 29),
-        new SourceToken(RPAREN, 29, 30),
-        new SourceToken(COMMA, 30, 31),
-        new SourceToken(IDENTIFIER, 32, 33),
-        new SourceToken(EXISTENCE, 33, 34),
-        new SourceToken(CALL_START, 34, 35),
-        new SourceToken(CALL_END, 35, 36),
-        new SourceToken(CALL_END, 36, 37),
-        new SourceToken(CALL_END, 37, 38),
-        new SourceToken(CALL_END, 38, 39)
+        new SourceToken(SourceType.IDENTIFIER, 0, 1),
+        new SourceToken(SourceType.CALL_START, 1, 2),
+        new SourceToken(SourceType.SUPER, 2, 7),
+        new SourceToken(SourceType.CALL_START, 7, 8),
+        new SourceToken(SourceType.AT, 8, 9),
+        new SourceToken(SourceType.CALL_START, 9, 10),
+        new SourceToken(SourceType.IDENTIFIER, 10, 11),
+        new SourceToken(SourceType.LBRACKET, 11, 12),
+        new SourceToken(SourceType.NUMBER, 12, 13),
+        new SourceToken(SourceType.RBRACKET, 13, 14),
+        new SourceToken(SourceType.CALL_START, 14, 15),
+        new SourceToken(SourceType.CALL_END, 15, 16),
+        new SourceToken(SourceType.COMMA, 16, 17),
+        new SourceToken(SourceType.BOOL, 18, 22),
+        new SourceToken(SourceType.OPERATOR, 22, 23),
+        new SourceToken(SourceType.LPAREN, 23, 24),
+        new SourceToken(SourceType.BOOL, 24, 29),
+        new SourceToken(SourceType.RPAREN, 29, 30),
+        new SourceToken(SourceType.COMMA, 30, 31),
+        new SourceToken(SourceType.IDENTIFIER, 32, 33),
+        new SourceToken(SourceType.EXISTENCE, 33, 34),
+        new SourceToken(SourceType.CALL_START, 34, 35),
+        new SourceToken(SourceType.CALL_END, 35, 36),
+        new SourceToken(SourceType.CALL_END, 36, 37),
+        new SourceToken(SourceType.CALL_END, 37, 38),
+        new SourceToken(SourceType.CALL_END, 38, 39)
       ]
     );
   });
@@ -310,11 +238,11 @@ describe('lexTest', () => {
     deepEqual(
       lex('a()()').toArray(),
       [
-        new SourceToken(IDENTIFIER, 0, 1),
-        new SourceToken(CALL_START, 1, 2),
-        new SourceToken(CALL_END, 2, 3),
-        new SourceToken(CALL_START, 3, 4),
-        new SourceToken(CALL_END, 4, 5)
+        new SourceToken(SourceType.IDENTIFIER, 0, 1),
+        new SourceToken(SourceType.CALL_START, 1, 2),
+        new SourceToken(SourceType.CALL_END, 2, 3),
+        new SourceToken(SourceType.CALL_START, 3, 4),
+        new SourceToken(SourceType.CALL_END, 4, 5)
       ]
     );
   });
@@ -323,17 +251,17 @@ describe('lexTest', () => {
     deepEqual(
       lex(`{ id: "#{a}" }`).toArray(),
       [
-        new SourceToken(LBRACE, 0, 1),
-        new SourceToken(IDENTIFIER, 2, 4),
-        new SourceToken(COLON, 4, 5),
-        new SourceToken(DSTRING_START, 6, 7),
-        new SourceToken(STRING_CONTENT, 7, 7),
-        new SourceToken(INTERPOLATION_START, 7, 9),
-        new SourceToken(IDENTIFIER, 9, 10),
-        new SourceToken(INTERPOLATION_END, 10, 11),
-        new SourceToken(STRING_CONTENT, 11, 11),
-        new SourceToken(DSTRING_END, 11, 12),
-        new SourceToken(RBRACE, 13, 14)
+        new SourceToken(SourceType.LBRACE, 0, 1),
+        new SourceToken(SourceType.IDENTIFIER, 2, 4),
+        new SourceToken(SourceType.COLON, 4, 5),
+        new SourceToken(SourceType.DSTRING_START, 6, 7),
+        new SourceToken(SourceType.STRING_CONTENT, 7, 7),
+        new SourceToken(SourceType.INTERPOLATION_START, 7, 9),
+        new SourceToken(SourceType.IDENTIFIER, 9, 10),
+        new SourceToken(SourceType.INTERPOLATION_END, 10, 11),
+        new SourceToken(SourceType.STRING_CONTENT, 11, 11),
+        new SourceToken(SourceType.DSTRING_END, 11, 12),
+        new SourceToken(SourceType.RBRACE, 13, 14)
       ]
     );
   });
@@ -342,15 +270,15 @@ describe('lexTest', () => {
     deepEqual(
       lex(`foo = '''\n      abc\n\n      def\n      '''`).toArray(),
       [
-        new SourceToken(IDENTIFIER, 0, 3),
-        new SourceToken(OPERATOR, 4, 5),
-        new SourceToken(TSSTRING_START, 6, 9),
-        new SourceToken(STRING_PADDING, 9, 16),
-        new SourceToken(STRING_CONTENT, 16, 21),
-        new SourceToken(STRING_PADDING, 21, 27),
-        new SourceToken(STRING_CONTENT, 27, 30),
-        new SourceToken(STRING_PADDING, 30, 37),
-        new SourceToken(TSSTRING_END, 37, 40)
+        new SourceToken(SourceType.IDENTIFIER, 0, 3),
+        new SourceToken(SourceType.OPERATOR, 4, 5),
+        new SourceToken(SourceType.TSSTRING_START, 6, 9),
+        new SourceToken(SourceType.STRING_PADDING, 9, 16),
+        new SourceToken(SourceType.STRING_CONTENT, 16, 21),
+        new SourceToken(SourceType.STRING_PADDING, 21, 27),
+        new SourceToken(SourceType.STRING_CONTENT, 27, 30),
+        new SourceToken(SourceType.STRING_PADDING, 30, 37),
+        new SourceToken(SourceType.TSSTRING_END, 37, 40)
       ]
     );
   });
@@ -359,10 +287,10 @@ describe('lexTest', () => {
     deepEqual(
       lex(`@on()`).toArray(),
       [
-        new SourceToken(AT, 0, 1),
-        new SourceToken(IDENTIFIER, 1, 3),
-        new SourceToken(CALL_START, 3, 4),
-        new SourceToken(CALL_END, 4, 5),
+        new SourceToken(SourceType.AT, 0, 1),
+        new SourceToken(SourceType.IDENTIFIER, 1, 3),
+        new SourceToken(SourceType.CALL_START, 3, 4),
+        new SourceToken(SourceType.CALL_END, 4, 5),
       ]
     );
   });
@@ -372,7 +300,7 @@ describe('SourceTokenListTest', () => {
   it('has a `startIndex` that represents the first token', () => {
     let list = lex('0');
     let token = list.tokenAtIndex(list.startIndex);
-    deepEqual(token, new SourceToken(NUMBER, 0, 1));
+    deepEqual(token, new SourceToken(SourceType.NUMBER, 0, 1));
   });
 
   it('has an `endIndex` that represents the virtual token after the last one', () => {
@@ -460,15 +388,15 @@ describe('SourceTokenListTest', () => {
     let plusIndex = oneIndex.next();
     let twoIndex = plusIndex && plusIndex.next();
     strictEqual(
-      list.indexOfTokenMatchingPredicate(token => token.type === IDENTIFIER),
+      list.indexOfTokenMatchingPredicate(token => token.type === SourceType.IDENTIFIER),
       oneIndex
     );
     strictEqual(
-      list.indexOfTokenMatchingPredicate(token => token.type === IDENTIFIER, plusIndex),
+      list.indexOfTokenMatchingPredicate(token => token.type === SourceType.IDENTIFIER, plusIndex),
       twoIndex
     );
     strictEqual(
-      list.indexOfTokenMatchingPredicate(token => token.type === IDENTIFIER, plusIndex, twoIndex),
+      list.indexOfTokenMatchingPredicate(token => token.type === SourceType.IDENTIFIER, plusIndex, twoIndex),
       null
     );
   });
@@ -479,15 +407,15 @@ describe('SourceTokenListTest', () => {
     let plusIndex = oneIndex.next();
     let twoIndex = plusIndex && plusIndex.next();
     strictEqual(
-      list.lastIndexOfTokenMatchingPredicate(token => token.type === IDENTIFIER),
+      list.lastIndexOfTokenMatchingPredicate(token => token.type === SourceType.IDENTIFIER),
       twoIndex
     );
     strictEqual(
-      list.lastIndexOfTokenMatchingPredicate(token => token.type === IDENTIFIER, plusIndex),
+      list.lastIndexOfTokenMatchingPredicate(token => token.type === SourceType.IDENTIFIER, plusIndex),
       oneIndex
     );
     strictEqual(
-      list.lastIndexOfTokenMatchingPredicate(token => token.type === IDENTIFIER, plusIndex, oneIndex),
+      list.lastIndexOfTokenMatchingPredicate(token => token.type === SourceType.IDENTIFIER, plusIndex, oneIndex),
       null
     );
   });
@@ -572,9 +500,9 @@ describe('SourceTokenListTest', () => {
 
     strictEqual(
       interpolationStartToken.type,
-      INTERPOLATION_START,
+      SourceType.INTERPOLATION_START,
       `expected ${inspect(interpolationStartToken)} to have type ` +
-      INTERPOLATION_START.name
+      SourceType[SourceType.INTERPOLATION_START]
     );
 
     let range = list.rangeOfInterpolatedStringTokensContainingTokenIndex(
@@ -590,15 +518,15 @@ describe('SourceTokenListTest', () => {
     deepEqual(
       list.map(t => t.type),
       [
-        DSTRING_START,
-        STRING_CONTENT,
-        INTERPOLATION_START,
-        DSTRING_START,
-        STRING_CONTENT,
-        DSTRING_END,
-        INTERPOLATION_END,
-        STRING_CONTENT,
-        DSTRING_END,
+        SourceType.DSTRING_START,
+        SourceType.STRING_CONTENT,
+        SourceType.INTERPOLATION_START,
+        SourceType.DSTRING_START,
+        SourceType.STRING_CONTENT,
+        SourceType.DSTRING_END,
+        SourceType.INTERPOLATION_END,
+        SourceType.STRING_CONTENT,
+        SourceType.DSTRING_END,
       ]
     );
 
@@ -622,13 +550,13 @@ describe('SourceTokenListTest', () => {
    deepEqual(
      list.map(t => t.type),
      [
-       HEREGEXP_START,
-       STRING_CONTENT,
-       INTERPOLATION_START,
-       IDENTIFIER,
-       INTERPOLATION_END,
-       STRING_CONTENT,
-       HEREGEXP_END,
+       SourceType.HEREGEXP_START,
+       SourceType.STRING_CONTENT,
+       SourceType.INTERPOLATION_START,
+       SourceType.IDENTIFIER,
+       SourceType.INTERPOLATION_END,
+       SourceType.STRING_CONTENT,
+       SourceType.HEREGEXP_END,
      ]
    );
 
@@ -692,927 +620,927 @@ describe('streamTest', () => {
     checkLocations(
       stream(''),
       [
-        new SourceLocation(EOF, 0)
+        new SourceLocation(SourceType.EOF, 0)
       ]
     );
    });
 
-  it('identifies single-quoted strings', () => { 
+  it('identifies single-quoted strings', () => {
     checkLocations(
       stream(`'abc'`),
       [
-        new SourceLocation(SSTRING_START, 0),
-        new SourceLocation(STRING_CONTENT, 1),
-        new SourceLocation(SSTRING_END, 4),
-        new SourceLocation(EOF, 5)
+        new SourceLocation(SourceType.SSTRING_START, 0),
+        new SourceLocation(SourceType.STRING_CONTENT, 1),
+        new SourceLocation(SourceType.SSTRING_END, 4),
+        new SourceLocation(SourceType.EOF, 5)
       ]
     );
    });
 
-  it('identifies double-quoted strings', () => { 
+  it('identifies double-quoted strings', () => {
     checkLocations(
       stream(`"abc"`),
       [
-        new SourceLocation(DSTRING_START, 0),
-        new SourceLocation(STRING_CONTENT, 1),
-        new SourceLocation(DSTRING_END, 4),
-        new SourceLocation(EOF, 5)
+        new SourceLocation(SourceType.DSTRING_START, 0),
+        new SourceLocation(SourceType.STRING_CONTENT, 1),
+        new SourceLocation(SourceType.DSTRING_END, 4),
+        new SourceLocation(SourceType.EOF, 5)
       ]
     );
    });
 
-  it('identifies triple-single-quoted strings', () => { 
+  it('identifies triple-single-quoted strings', () => {
     checkLocations(
       stream(`'''abc'''`),
       [
-        new SourceLocation(TSSTRING_START, 0),
-        new SourceLocation(STRING_CONTENT, 3),
-        new SourceLocation(TSSTRING_END, 6),
-        new SourceLocation(EOF, 9)
+        new SourceLocation(SourceType.TSSTRING_START, 0),
+        new SourceLocation(SourceType.STRING_CONTENT, 3),
+        new SourceLocation(SourceType.TSSTRING_END, 6),
+        new SourceLocation(SourceType.EOF, 9)
       ]
     );
    });
 
-  it('identifies triple-double-quoted strings', () => { 
+  it('identifies triple-double-quoted strings', () => {
     checkLocations(
       stream(`"""abc"""`),
       [
-        new SourceLocation(TDSTRING_START, 0),
-        new SourceLocation(STRING_CONTENT, 3),
-        new SourceLocation(TDSTRING_END, 6),
-        new SourceLocation(EOF, 9)
+        new SourceLocation(SourceType.TDSTRING_START, 0),
+        new SourceLocation(SourceType.STRING_CONTENT, 3),
+        new SourceLocation(SourceType.TDSTRING_END, 6),
+        new SourceLocation(SourceType.EOF, 9)
       ]
     );
    });
 
-  it('identifies identifiers', () => { 
+  it('identifies identifiers', () => {
     checkLocations(
       stream(`a`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(EOF, 1)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.EOF, 1)
       ]
     );
    });
 
-  it('identifies whitespace', () => { 
+  it('identifies whitespace', () => {
     checkLocations(
       stream(`a b`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(SPACE, 1),
-        new SourceLocation(IDENTIFIER, 2),
-        new SourceLocation(EOF, 3)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.SPACE, 1),
+        new SourceLocation(SourceType.IDENTIFIER, 2),
+        new SourceLocation(SourceType.EOF, 3)
       ]
     );
    });
 
-  it('transitions to INTERPOLATION_START at a string interpolation', () => { 
+  it('transitions to INTERPOLATION_START at a string interpolation', () => {
     checkLocations(
       stream(`"a#{b}c"`),
       [
-        new SourceLocation(DSTRING_START, 0),
-        new SourceLocation(STRING_CONTENT, 1),
-        new SourceLocation(INTERPOLATION_START, 2),
-        new SourceLocation(IDENTIFIER, 4),
-        new SourceLocation(INTERPOLATION_END, 5),
-        new SourceLocation(STRING_CONTENT, 6),
-        new SourceLocation(DSTRING_END, 7),
-        new SourceLocation(EOF, 8)
+        new SourceLocation(SourceType.DSTRING_START, 0),
+        new SourceLocation(SourceType.STRING_CONTENT, 1),
+        new SourceLocation(SourceType.INTERPOLATION_START, 2),
+        new SourceLocation(SourceType.IDENTIFIER, 4),
+        new SourceLocation(SourceType.INTERPOLATION_END, 5),
+        new SourceLocation(SourceType.STRING_CONTENT, 6),
+        new SourceLocation(SourceType.DSTRING_END, 7),
+        new SourceLocation(SourceType.EOF, 8)
       ]
     );
    });
 
-  it('handles nested string interpolation', () => { 
+  it('handles nested string interpolation', () => {
     checkLocations(
       stream(`"#{"#{}"}"`),
       [
-        new SourceLocation(DSTRING_START, 0),
-        new SourceLocation(STRING_CONTENT, 1),
-        new SourceLocation(INTERPOLATION_START, 1),
-        new SourceLocation(DSTRING_START, 3),
-        new SourceLocation(STRING_CONTENT, 4),
-        new SourceLocation(INTERPOLATION_START, 4),
-        new SourceLocation(INTERPOLATION_END, 6),
-        new SourceLocation(STRING_CONTENT, 7),
-        new SourceLocation(DSTRING_END, 7),
-        new SourceLocation(INTERPOLATION_END, 8),
-        new SourceLocation(STRING_CONTENT, 9),
-        new SourceLocation(DSTRING_END, 9),
-        new SourceLocation(EOF, 10)
+        new SourceLocation(SourceType.DSTRING_START, 0),
+        new SourceLocation(SourceType.STRING_CONTENT, 1),
+        new SourceLocation(SourceType.INTERPOLATION_START, 1),
+        new SourceLocation(SourceType.DSTRING_START, 3),
+        new SourceLocation(SourceType.STRING_CONTENT, 4),
+        new SourceLocation(SourceType.INTERPOLATION_START, 4),
+        new SourceLocation(SourceType.INTERPOLATION_END, 6),
+        new SourceLocation(SourceType.STRING_CONTENT, 7),
+        new SourceLocation(SourceType.DSTRING_END, 7),
+        new SourceLocation(SourceType.INTERPOLATION_END, 8),
+        new SourceLocation(SourceType.STRING_CONTENT, 9),
+        new SourceLocation(SourceType.DSTRING_END, 9),
+        new SourceLocation(SourceType.EOF, 10)
       ]
     );
    });
 
-  it('identifies integers as numbers', () => { 
+  it('identifies integers as numbers', () => {
     checkLocations(
       stream(`10`),
       [
-        new SourceLocation(NUMBER, 0),
-        new SourceLocation(EOF, 2)
+        new SourceLocation(SourceType.NUMBER, 0),
+        new SourceLocation(SourceType.EOF, 2)
       ]
     );
    });
 
-  it('identifies + as an operator', () => { 
+  it('identifies + as an operator', () => {
     checkLocations(
       stream(`a + b`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(SPACE, 1),
-        new SourceLocation(OPERATOR, 2),
-        new SourceLocation(SPACE, 3),
-        new SourceLocation(IDENTIFIER, 4),
-        new SourceLocation(EOF, 5)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.SPACE, 1),
+        new SourceLocation(SourceType.OPERATOR, 2),
+        new SourceLocation(SourceType.SPACE, 3),
+        new SourceLocation(SourceType.IDENTIFIER, 4),
+        new SourceLocation(SourceType.EOF, 5)
       ]
     );
    });
 
-  it('identifies opening and closing parentheses', () => { 
+  it('identifies opening and closing parentheses', () => {
     checkLocations(
       stream(`(b)*2`),
       [
-        new SourceLocation(LPAREN, 0),
-        new SourceLocation(IDENTIFIER, 1),
-        new SourceLocation(RPAREN, 2),
-        new SourceLocation(OPERATOR, 3),
-        new SourceLocation(NUMBER, 4),
-        new SourceLocation(EOF, 5)
+        new SourceLocation(SourceType.LPAREN, 0),
+        new SourceLocation(SourceType.IDENTIFIER, 1),
+        new SourceLocation(SourceType.RPAREN, 2),
+        new SourceLocation(SourceType.OPERATOR, 3),
+        new SourceLocation(SourceType.NUMBER, 4),
+        new SourceLocation(SourceType.EOF, 5)
       ]
     );
    });
 
-  it('identifies opening and closing braces', () => { 
+  it('identifies opening and closing braces', () => {
     checkLocations(
       stream(`{ a: '{}' }`),
       [
-        new SourceLocation(LBRACE, 0),
-        new SourceLocation(SPACE, 1),
-        new SourceLocation(IDENTIFIER, 2),
-        new SourceLocation(COLON, 3),
-        new SourceLocation(SPACE, 4),
-        new SourceLocation(SSTRING_START, 5),
-        new SourceLocation(STRING_CONTENT, 6),
-        new SourceLocation(SSTRING_END, 8),
-        new SourceLocation(SPACE, 9),
-        new SourceLocation(RBRACE, 10),
-        new SourceLocation(EOF, 11)
+        new SourceLocation(SourceType.LBRACE, 0),
+        new SourceLocation(SourceType.SPACE, 1),
+        new SourceLocation(SourceType.IDENTIFIER, 2),
+        new SourceLocation(SourceType.COLON, 3),
+        new SourceLocation(SourceType.SPACE, 4),
+        new SourceLocation(SourceType.SSTRING_START, 5),
+        new SourceLocation(SourceType.STRING_CONTENT, 6),
+        new SourceLocation(SourceType.SSTRING_END, 8),
+        new SourceLocation(SourceType.SPACE, 9),
+        new SourceLocation(SourceType.RBRACE, 10),
+        new SourceLocation(SourceType.EOF, 11)
       ]
     );
    });
 
-  it('identifies opening and closing brackets', () => { 
+  it('identifies opening and closing brackets', () => {
     checkLocations(
       stream(`[ a[1], b['f]['] ]`),
       [
-        new SourceLocation(LBRACKET, 0),
-        new SourceLocation(SPACE, 1),
-        new SourceLocation(IDENTIFIER, 2),
-        new SourceLocation(LBRACKET, 3),
-        new SourceLocation(NUMBER, 4),
-        new SourceLocation(RBRACKET, 5),
-        new SourceLocation(COMMA, 6),
-        new SourceLocation(SPACE, 7),
-        new SourceLocation(IDENTIFIER, 8),
-        new SourceLocation(LBRACKET, 9),
-        new SourceLocation(SSTRING_START, 10),
-        new SourceLocation(STRING_CONTENT, 11),
-        new SourceLocation(SSTRING_END, 14),
-        new SourceLocation(RBRACKET, 15),
-        new SourceLocation(SPACE, 16),
-        new SourceLocation(RBRACKET, 17),
-        new SourceLocation(EOF, 18)
+        new SourceLocation(SourceType.LBRACKET, 0),
+        new SourceLocation(SourceType.SPACE, 1),
+        new SourceLocation(SourceType.IDENTIFIER, 2),
+        new SourceLocation(SourceType.LBRACKET, 3),
+        new SourceLocation(SourceType.NUMBER, 4),
+        new SourceLocation(SourceType.RBRACKET, 5),
+        new SourceLocation(SourceType.COMMA, 6),
+        new SourceLocation(SourceType.SPACE, 7),
+        new SourceLocation(SourceType.IDENTIFIER, 8),
+        new SourceLocation(SourceType.LBRACKET, 9),
+        new SourceLocation(SourceType.SSTRING_START, 10),
+        new SourceLocation(SourceType.STRING_CONTENT, 11),
+        new SourceLocation(SourceType.SSTRING_END, 14),
+        new SourceLocation(SourceType.RBRACKET, 15),
+        new SourceLocation(SourceType.SPACE, 16),
+        new SourceLocation(SourceType.RBRACKET, 17),
+        new SourceLocation(SourceType.EOF, 18)
       ]
     );
    });
 
-  it('identifies embedded JavaScript', () => { 
+  it('identifies embedded JavaScript', () => {
     checkLocations(
       stream('`1` + 2'),
       [
-        new SourceLocation(JS, 0),
-        new SourceLocation(SPACE, 3),
-        new SourceLocation(OPERATOR, 4),
-        new SourceLocation(SPACE, 5),
-        new SourceLocation(NUMBER, 6),
-        new SourceLocation(EOF, 7)
+        new SourceLocation(SourceType.JS, 0),
+        new SourceLocation(SourceType.SPACE, 3),
+        new SourceLocation(SourceType.OPERATOR, 4),
+        new SourceLocation(SourceType.SPACE, 5),
+        new SourceLocation(SourceType.NUMBER, 6),
+        new SourceLocation(SourceType.EOF, 7)
       ]
     );
    });
 
-  it('identifies LF as a newline', () => { 
+  it('identifies LF as a newline', () => {
     checkLocations(
       stream(`a\nb`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(NEWLINE, 1),
-        new SourceLocation(IDENTIFIER, 2),
-        new SourceLocation(EOF, 3)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.NEWLINE, 1),
+        new SourceLocation(SourceType.IDENTIFIER, 2),
+        new SourceLocation(SourceType.EOF, 3)
       ]
     );
    });
 
-  it('identifies @', () => { 
+  it('identifies @', () => {
     checkLocations(
       stream(`@a`),
       [
-        new SourceLocation(AT, 0),
-        new SourceLocation(IDENTIFIER, 1),
-        new SourceLocation(EOF, 2)
+        new SourceLocation(SourceType.AT, 0),
+        new SourceLocation(SourceType.IDENTIFIER, 1),
+        new SourceLocation(SourceType.EOF, 2)
       ]
     );
    });
 
-  it('identifies semicolons', () => { 
+  it('identifies semicolons', () => {
     checkLocations(
       stream(`a; b`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(SEMICOLON, 1),
-        new SourceLocation(SPACE, 2),
-        new SourceLocation(IDENTIFIER, 3),
-        new SourceLocation(EOF, 4)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.SEMICOLON, 1),
+        new SourceLocation(SourceType.SPACE, 2),
+        new SourceLocation(SourceType.IDENTIFIER, 3),
+        new SourceLocation(SourceType.EOF, 4)
       ]
     );
    });
 
-  it('identifies adjacent operators as distinct', () => { 
+  it('identifies adjacent operators as distinct', () => {
     checkLocations(
       stream(`a=++b`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(OPERATOR, 1),
-        new SourceLocation(OPERATOR, 2),
-        new SourceLocation(IDENTIFIER, 4),
-        new SourceLocation(EOF, 5)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.OPERATOR, 1),
+        new SourceLocation(SourceType.OPERATOR, 2),
+        new SourceLocation(SourceType.IDENTIFIER, 4),
+        new SourceLocation(SourceType.EOF, 5)
       ]
     );
    });
 
-  it('identifies comparison operators', () => { 
+  it('identifies comparison operators', () => {
     checkLocations(
       stream(`a < b <= c; a > b >= c`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(SPACE, 1),
-        new SourceLocation(OPERATOR, 2),
-        new SourceLocation(SPACE, 3),
-        new SourceLocation(IDENTIFIER, 4),
-        new SourceLocation(SPACE, 5),
-        new SourceLocation(OPERATOR, 6),
-        new SourceLocation(SPACE, 8),
-        new SourceLocation(IDENTIFIER, 9),
-        new SourceLocation(SEMICOLON, 10),
-        new SourceLocation(SPACE, 11),
-        new SourceLocation(IDENTIFIER, 12),
-        new SourceLocation(SPACE, 13),
-        new SourceLocation(OPERATOR, 14),
-        new SourceLocation(SPACE, 15),
-        new SourceLocation(IDENTIFIER, 16),
-        new SourceLocation(SPACE, 17),
-        new SourceLocation(OPERATOR, 18),
-        new SourceLocation(SPACE, 20),
-        new SourceLocation(IDENTIFIER, 21),
-        new SourceLocation(EOF, 22)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.SPACE, 1),
+        new SourceLocation(SourceType.OPERATOR, 2),
+        new SourceLocation(SourceType.SPACE, 3),
+        new SourceLocation(SourceType.IDENTIFIER, 4),
+        new SourceLocation(SourceType.SPACE, 5),
+        new SourceLocation(SourceType.OPERATOR, 6),
+        new SourceLocation(SourceType.SPACE, 8),
+        new SourceLocation(SourceType.IDENTIFIER, 9),
+        new SourceLocation(SourceType.SEMICOLON, 10),
+        new SourceLocation(SourceType.SPACE, 11),
+        new SourceLocation(SourceType.IDENTIFIER, 12),
+        new SourceLocation(SourceType.SPACE, 13),
+        new SourceLocation(SourceType.OPERATOR, 14),
+        new SourceLocation(SourceType.SPACE, 15),
+        new SourceLocation(SourceType.IDENTIFIER, 16),
+        new SourceLocation(SourceType.SPACE, 17),
+        new SourceLocation(SourceType.OPERATOR, 18),
+        new SourceLocation(SourceType.SPACE, 20),
+        new SourceLocation(SourceType.IDENTIFIER, 21),
+        new SourceLocation(SourceType.EOF, 22)
       ]
     );
    });
 
-  it('identifies dots', () => { 
+  it('identifies dots', () => {
     checkLocations(
       stream(`a.b`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(DOT, 1),
-        new SourceLocation(IDENTIFIER, 2),
-        new SourceLocation(EOF, 3)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.DOT, 1),
+        new SourceLocation(SourceType.IDENTIFIER, 2),
+        new SourceLocation(SourceType.EOF, 3)
       ]
     );
    });
 
-  it('identifies block comments', () => { 
+  it('identifies block comments', () => {
     checkLocations(
       stream(`### a ###`),
       [
-        new SourceLocation(HERECOMMENT, 0),
-        new SourceLocation(EOF, 9)
+        new SourceLocation(SourceType.HERECOMMENT, 0),
+        new SourceLocation(SourceType.EOF, 9)
       ]
     );
    });
 
-  it('does not treat markdown-style headings as block comments', () => { 
+  it('does not treat markdown-style headings as block comments', () => {
     checkLocations(
       stream(`#### FOO`),
       [
-        new SourceLocation(COMMENT, 0),
-        new SourceLocation(EOF, 8)
+        new SourceLocation(SourceType.COMMENT, 0),
+        new SourceLocation(SourceType.EOF, 8)
       ]
     );
    });
 
-  it('treats `->` as a function', () => { 
+  it('treats `->` as a function', () => {
     checkLocations(
       stream(`-> a`),
       [
-        new SourceLocation(FUNCTION, 0),
-        new SourceLocation(SPACE, 2),
-        new SourceLocation(IDENTIFIER, 3),
-        new SourceLocation(EOF, 4)
+        new SourceLocation(SourceType.FUNCTION, 0),
+        new SourceLocation(SourceType.SPACE, 2),
+        new SourceLocation(SourceType.IDENTIFIER, 3),
+        new SourceLocation(SourceType.EOF, 4)
       ]
     );
    });
 
-  it('treats `=>` as a function', () => { 
+  it('treats `=>` as a function', () => {
     checkLocations(
       stream(`=> a`),
       [
-        new SourceLocation(FUNCTION, 0),
-        new SourceLocation(SPACE, 2),
-        new SourceLocation(IDENTIFIER, 3),
-        new SourceLocation(EOF, 4)
+        new SourceLocation(SourceType.FUNCTION, 0),
+        new SourceLocation(SourceType.SPACE, 2),
+        new SourceLocation(SourceType.IDENTIFIER, 3),
+        new SourceLocation(SourceType.EOF, 4)
       ]
     );
    });
 
-  it('identifies division as distinct from regular expressions', () => { 
+  it('identifies division as distinct from regular expressions', () => {
     checkLocations(
       stream(`1/0 + 2/4`),
       [
-        new SourceLocation(NUMBER, 0),
-        new SourceLocation(OPERATOR, 1),
-        new SourceLocation(NUMBER, 2),
-        new SourceLocation(SPACE, 3),
-        new SourceLocation(OPERATOR, 4),
-        new SourceLocation(SPACE, 5),
-        new SourceLocation(NUMBER, 6),
-        new SourceLocation(OPERATOR, 7),
-        new SourceLocation(NUMBER, 8),
-        new SourceLocation(EOF, 9)
+        new SourceLocation(SourceType.NUMBER, 0),
+        new SourceLocation(SourceType.OPERATOR, 1),
+        new SourceLocation(SourceType.NUMBER, 2),
+        new SourceLocation(SourceType.SPACE, 3),
+        new SourceLocation(SourceType.OPERATOR, 4),
+        new SourceLocation(SourceType.SPACE, 5),
+        new SourceLocation(SourceType.NUMBER, 6),
+        new SourceLocation(SourceType.OPERATOR, 7),
+        new SourceLocation(SourceType.NUMBER, 8),
+        new SourceLocation(SourceType.EOF, 9)
       ]
     );
    });
 
-  it('identifies regular expressions as RHS in assignment', () => { 
+  it('identifies regular expressions as RHS in assignment', () => {
     checkLocations(
       stream(`a = /foo/`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(SPACE, 1),
-        new SourceLocation(OPERATOR, 2),
-        new SourceLocation(SPACE, 3),
-        new SourceLocation(REGEXP, 4),
-        new SourceLocation(EOF, 9)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.SPACE, 1),
+        new SourceLocation(SourceType.OPERATOR, 2),
+        new SourceLocation(SourceType.SPACE, 3),
+        new SourceLocation(SourceType.REGEXP, 4),
+        new SourceLocation(SourceType.EOF, 9)
       ]
     );
    });
 
-  it('identifies regular expressions at the start of the source', () => { 
+  it('identifies regular expressions at the start of the source', () => {
     checkLocations(
       stream(`/foo/.test 'abc'`),
       [
-        new SourceLocation(REGEXP, 0),
-        new SourceLocation(DOT, 5),
-        new SourceLocation(IDENTIFIER, 6),
-        new SourceLocation(SPACE, 10),
-        new SourceLocation(SSTRING_START, 11),
-        new SourceLocation(STRING_CONTENT, 12),
-        new SourceLocation(SSTRING_END, 15),
-        new SourceLocation(EOF, 16)
+        new SourceLocation(SourceType.REGEXP, 0),
+        new SourceLocation(SourceType.DOT, 5),
+        new SourceLocation(SourceType.IDENTIFIER, 6),
+        new SourceLocation(SourceType.SPACE, 10),
+        new SourceLocation(SourceType.SSTRING_START, 11),
+        new SourceLocation(SourceType.STRING_CONTENT, 12),
+        new SourceLocation(SourceType.SSTRING_END, 15),
+        new SourceLocation(SourceType.EOF, 16)
       ]
     );
    });
 
-  it('identifies simple heregexes', () => { 
+  it('identifies simple heregexes', () => {
     checkLocations(
       stream(`///abc///g.test 'foo'`),
       [
-        new SourceLocation(HEREGEXP_START, 0),
-        new SourceLocation(STRING_CONTENT, 3),
-        new SourceLocation(HEREGEXP_END, 6),
-        new SourceLocation(DOT, 10),
-        new SourceLocation(IDENTIFIER, 11),
-        new SourceLocation(SPACE, 15),
-        new SourceLocation(SSTRING_START, 16),
-        new SourceLocation(STRING_CONTENT, 17),
-        new SourceLocation(SSTRING_END, 20),
-        new SourceLocation(EOF, 21)
+        new SourceLocation(SourceType.HEREGEXP_START, 0),
+        new SourceLocation(SourceType.STRING_CONTENT, 3),
+        new SourceLocation(SourceType.HEREGEXP_END, 6),
+        new SourceLocation(SourceType.DOT, 10),
+        new SourceLocation(SourceType.IDENTIFIER, 11),
+        new SourceLocation(SourceType.SPACE, 15),
+        new SourceLocation(SourceType.SSTRING_START, 16),
+        new SourceLocation(SourceType.STRING_CONTENT, 17),
+        new SourceLocation(SourceType.SSTRING_END, 20),
+        new SourceLocation(SourceType.EOF, 21)
       ]
     );
    });
 
-  it('identifies heregexes with interpolations', () => { 
+  it('identifies heregexes with interpolations', () => {
     checkLocations(
       stream(`///abc\ndef#{g}  # this is a comment\nhij///g.test 'foo'`),
       [
-        new SourceLocation(HEREGEXP_START, 0),
-        new SourceLocation(STRING_CONTENT, 3),
-        new SourceLocation(INTERPOLATION_START, 10),
-        new SourceLocation(IDENTIFIER, 12),
-        new SourceLocation(INTERPOLATION_END, 13),
-        new SourceLocation(STRING_CONTENT, 14),
-        new SourceLocation(HEREGEXP_END, 39),
-        new SourceLocation(DOT, 43),
-        new SourceLocation(IDENTIFIER, 44),
-        new SourceLocation(SPACE, 48),
-        new SourceLocation(SSTRING_START, 49),
-        new SourceLocation(STRING_CONTENT, 50),
-        new SourceLocation(SSTRING_END, 53),
-        new SourceLocation(EOF, 54)
+        new SourceLocation(SourceType.HEREGEXP_START, 0),
+        new SourceLocation(SourceType.STRING_CONTENT, 3),
+        new SourceLocation(SourceType.INTERPOLATION_START, 10),
+        new SourceLocation(SourceType.IDENTIFIER, 12),
+        new SourceLocation(SourceType.INTERPOLATION_END, 13),
+        new SourceLocation(SourceType.STRING_CONTENT, 14),
+        new SourceLocation(SourceType.HEREGEXP_END, 39),
+        new SourceLocation(SourceType.DOT, 43),
+        new SourceLocation(SourceType.IDENTIFIER, 44),
+        new SourceLocation(SourceType.SPACE, 48),
+        new SourceLocation(SourceType.SSTRING_START, 49),
+        new SourceLocation(SourceType.STRING_CONTENT, 50),
+        new SourceLocation(SourceType.SSTRING_END, 53),
+        new SourceLocation(SourceType.EOF, 54)
       ]
     );
    });
 
-  it('computes the right padding for heregexes with interpolations', () => { 
+  it('computes the right padding for heregexes with interpolations', () => {
     deepEqual(
       lex(`///abc\ndef#{g}  # this is a comment\nhij///g.test 'foo'`).toArray(),
       [
-        new SourceToken(HEREGEXP_START, 0, 3),
-        new SourceToken(STRING_CONTENT, 3, 6),
-        new SourceToken(STRING_PADDING, 6, 7),
-        new SourceToken(STRING_CONTENT, 7, 10),
-        new SourceToken(INTERPOLATION_START, 10, 12),
-        new SourceToken(IDENTIFIER, 12, 13),
-        new SourceToken(INTERPOLATION_END, 13, 14),
-        new SourceToken(STRING_PADDING, 14, 36),
-        new SourceToken(STRING_CONTENT, 36, 39),
-        new SourceToken(HEREGEXP_END, 39, 43),
-        new SourceToken(DOT, 43, 44),
-        new SourceToken(IDENTIFIER, 44, 48),
-        new SourceToken(SSTRING_START, 49, 50),
-        new SourceToken(STRING_CONTENT, 50, 53),
-        new SourceToken(SSTRING_END, 53, 54),
+        new SourceToken(SourceType.HEREGEXP_START, 0, 3),
+        new SourceToken(SourceType.STRING_CONTENT, 3, 6),
+        new SourceToken(SourceType.STRING_PADDING, 6, 7),
+        new SourceToken(SourceType.STRING_CONTENT, 7, 10),
+        new SourceToken(SourceType.INTERPOLATION_START, 10, 12),
+        new SourceToken(SourceType.IDENTIFIER, 12, 13),
+        new SourceToken(SourceType.INTERPOLATION_END, 13, 14),
+        new SourceToken(SourceType.STRING_PADDING, 14, 36),
+        new SourceToken(SourceType.STRING_CONTENT, 36, 39),
+        new SourceToken(SourceType.HEREGEXP_END, 39, 43),
+        new SourceToken(SourceType.DOT, 43, 44),
+        new SourceToken(SourceType.IDENTIFIER, 44, 48),
+        new SourceToken(SourceType.SSTRING_START, 49, 50),
+        new SourceToken(SourceType.STRING_CONTENT, 50, 53),
+        new SourceToken(SourceType.SSTRING_END, 53, 54),
       ]
     );
    });
 
-  it('identifies keywords for conditionals', () => { 
+  it('identifies keywords for conditionals', () => {
     checkLocations(
       stream(`if a then b else c`),
       [
-        new SourceLocation(IF, 0),
-        new SourceLocation(SPACE, 2),
-        new SourceLocation(IDENTIFIER, 3),
-        new SourceLocation(SPACE, 4),
-        new SourceLocation(THEN, 5),
-        new SourceLocation(SPACE, 9),
-        new SourceLocation(IDENTIFIER, 10),
-        new SourceLocation(SPACE, 11),
-        new SourceLocation(ELSE, 12),
-        new SourceLocation(SPACE, 16),
-        new SourceLocation(IDENTIFIER, 17),
-        new SourceLocation(EOF, 18)
+        new SourceLocation(SourceType.IF, 0),
+        new SourceLocation(SourceType.SPACE, 2),
+        new SourceLocation(SourceType.IDENTIFIER, 3),
+        new SourceLocation(SourceType.SPACE, 4),
+        new SourceLocation(SourceType.THEN, 5),
+        new SourceLocation(SourceType.SPACE, 9),
+        new SourceLocation(SourceType.IDENTIFIER, 10),
+        new SourceLocation(SourceType.SPACE, 11),
+        new SourceLocation(SourceType.ELSE, 12),
+        new SourceLocation(SourceType.SPACE, 16),
+        new SourceLocation(SourceType.IDENTIFIER, 17),
+        new SourceLocation(SourceType.EOF, 18)
       ]
     );
    });
 
-  it('identifies keywords for `unless` conditionals', () => { 
+  it('identifies keywords for `unless` conditionals', () => {
     checkLocations(
       stream(`b unless a`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(SPACE, 1),
-        new SourceLocation(IF, 2),
-        new SourceLocation(SPACE, 8),
-        new SourceLocation(IDENTIFIER, 9),
-        new SourceLocation(EOF, 10)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.SPACE, 1),
+        new SourceLocation(SourceType.IF, 2),
+        new SourceLocation(SourceType.SPACE, 8),
+        new SourceLocation(SourceType.IDENTIFIER, 9),
+        new SourceLocation(SourceType.EOF, 10)
       ]
     );
    });
 
-  it('identifies keywords for switch', () => { 
+  it('identifies keywords for switch', () => {
     checkLocations(
       stream(`switch a\n  when b\n    c\n  else d`),
       [
-        new SourceLocation(SWITCH, 0),
-        new SourceLocation(SPACE, 6),
-        new SourceLocation(IDENTIFIER, 7),
-        new SourceLocation(NEWLINE, 8),
-        new SourceLocation(SPACE, 9),
-        new SourceLocation(WHEN, 11),
-        new SourceLocation(SPACE, 15),
-        new SourceLocation(IDENTIFIER, 16),
-        new SourceLocation(NEWLINE, 17),
-        new SourceLocation(SPACE, 18),
-        new SourceLocation(IDENTIFIER, 22),
-        new SourceLocation(NEWLINE, 23),
-        new SourceLocation(SPACE, 24),
-        new SourceLocation(ELSE, 26),
-        new SourceLocation(SPACE, 30),
-        new SourceLocation(IDENTIFIER, 31),
-        new SourceLocation(EOF, 32)
+        new SourceLocation(SourceType.SWITCH, 0),
+        new SourceLocation(SourceType.SPACE, 6),
+        new SourceLocation(SourceType.IDENTIFIER, 7),
+        new SourceLocation(SourceType.NEWLINE, 8),
+        new SourceLocation(SourceType.SPACE, 9),
+        new SourceLocation(SourceType.WHEN, 11),
+        new SourceLocation(SourceType.SPACE, 15),
+        new SourceLocation(SourceType.IDENTIFIER, 16),
+        new SourceLocation(SourceType.NEWLINE, 17),
+        new SourceLocation(SourceType.SPACE, 18),
+        new SourceLocation(SourceType.IDENTIFIER, 22),
+        new SourceLocation(SourceType.NEWLINE, 23),
+        new SourceLocation(SourceType.SPACE, 24),
+        new SourceLocation(SourceType.ELSE, 26),
+        new SourceLocation(SourceType.SPACE, 30),
+        new SourceLocation(SourceType.IDENTIFIER, 31),
+        new SourceLocation(SourceType.EOF, 32)
       ]
     );
    });
 
-  it('identifies keywords for `for` loops', () => { 
+  it('identifies keywords for `for` loops', () => {
     checkLocations(
       stream(`for own a in b then a`),
       [
-        new SourceLocation(FOR, 0),
-        new SourceLocation(SPACE, 3),
-        new SourceLocation(OWN, 4),
-        new SourceLocation(SPACE, 7),
-        new SourceLocation(IDENTIFIER, 8),
-        new SourceLocation(SPACE, 9),
-        new SourceLocation(RELATION, 10),
-        new SourceLocation(SPACE, 12),
-        new SourceLocation(IDENTIFIER, 13),
-        new SourceLocation(SPACE, 14),
-        new SourceLocation(THEN, 15),
-        new SourceLocation(SPACE, 19),
-        new SourceLocation(IDENTIFIER, 20),
-        new SourceLocation(EOF, 21)
+        new SourceLocation(SourceType.FOR, 0),
+        new SourceLocation(SourceType.SPACE, 3),
+        new SourceLocation(SourceType.OWN, 4),
+        new SourceLocation(SourceType.SPACE, 7),
+        new SourceLocation(SourceType.IDENTIFIER, 8),
+        new SourceLocation(SourceType.SPACE, 9),
+        new SourceLocation(SourceType.RELATION, 10),
+        new SourceLocation(SourceType.SPACE, 12),
+        new SourceLocation(SourceType.IDENTIFIER, 13),
+        new SourceLocation(SourceType.SPACE, 14),
+        new SourceLocation(SourceType.THEN, 15),
+        new SourceLocation(SourceType.SPACE, 19),
+        new SourceLocation(SourceType.IDENTIFIER, 20),
+        new SourceLocation(SourceType.EOF, 21)
       ]
     );
    });
 
-  it('identifies keywords for `while` loops', () => { 
+  it('identifies keywords for `while` loops', () => {
     checkLocations(
       stream(`loop then until a then while b then c`),
       [
-        new SourceLocation(LOOP, 0),
-        new SourceLocation(SPACE, 4),
-        new SourceLocation(THEN, 5),
-        new SourceLocation(SPACE, 9),
-        new SourceLocation(WHILE, 10),
-        new SourceLocation(SPACE, 15),
-        new SourceLocation(IDENTIFIER, 16),
-        new SourceLocation(SPACE, 17),
-        new SourceLocation(THEN, 18),
-        new SourceLocation(SPACE, 22),
-        new SourceLocation(WHILE, 23),
-        new SourceLocation(SPACE, 28),
-        new SourceLocation(IDENTIFIER, 29),
-        new SourceLocation(SPACE, 30),
-        new SourceLocation(THEN, 31),
-        new SourceLocation(SPACE, 35),
-        new SourceLocation(IDENTIFIER, 36),
-        new SourceLocation(EOF, 37)
+        new SourceLocation(SourceType.LOOP, 0),
+        new SourceLocation(SourceType.SPACE, 4),
+        new SourceLocation(SourceType.THEN, 5),
+        new SourceLocation(SourceType.SPACE, 9),
+        new SourceLocation(SourceType.WHILE, 10),
+        new SourceLocation(SourceType.SPACE, 15),
+        new SourceLocation(SourceType.IDENTIFIER, 16),
+        new SourceLocation(SourceType.SPACE, 17),
+        new SourceLocation(SourceType.THEN, 18),
+        new SourceLocation(SourceType.SPACE, 22),
+        new SourceLocation(SourceType.WHILE, 23),
+        new SourceLocation(SourceType.SPACE, 28),
+        new SourceLocation(SourceType.IDENTIFIER, 29),
+        new SourceLocation(SourceType.SPACE, 30),
+        new SourceLocation(SourceType.THEN, 31),
+        new SourceLocation(SourceType.SPACE, 35),
+        new SourceLocation(SourceType.IDENTIFIER, 36),
+        new SourceLocation(SourceType.EOF, 37)
       ]
     );
    });
 
-  it('identifies `class` as a keyword', () => { 
+  it('identifies `class` as a keyword', () => {
     checkLocations(
       stream(`class A`),
       [
-        new SourceLocation(CLASS, 0),
-        new SourceLocation(SPACE, 5),
-        new SourceLocation(IDENTIFIER, 6),
-        new SourceLocation(EOF, 7)
+        new SourceLocation(SourceType.CLASS, 0),
+        new SourceLocation(SourceType.SPACE, 5),
+        new SourceLocation(SourceType.IDENTIFIER, 6),
+        new SourceLocation(SourceType.EOF, 7)
       ]
     );
    });
 
-  it('identifies `return` as a keyword', () => { 
+  it('identifies `return` as a keyword', () => {
     checkLocations(
       stream(`return 0`),
       [
-        new SourceLocation(RETURN, 0),
-        new SourceLocation(SPACE, 6),
-        new SourceLocation(NUMBER, 7),
-        new SourceLocation(EOF, 8)
+        new SourceLocation(SourceType.RETURN, 0),
+        new SourceLocation(SourceType.SPACE, 6),
+        new SourceLocation(SourceType.NUMBER, 7),
+        new SourceLocation(SourceType.EOF, 8)
       ]
     );
    });
 
-  it('identifies `break` and `continue` as keywords', () => { 
+  it('identifies `break` and `continue` as keywords', () => {
     checkLocations(
       stream(`break;continue;`),
       [
-        new SourceLocation(BREAK, 0),
-        new SourceLocation(SEMICOLON, 5),
-        new SourceLocation(CONTINUE, 6),
-        new SourceLocation(SEMICOLON, 14),
-        new SourceLocation(EOF, 15)
+        new SourceLocation(SourceType.BREAK, 0),
+        new SourceLocation(SourceType.SEMICOLON, 5),
+        new SourceLocation(SourceType.CONTINUE, 6),
+        new SourceLocation(SourceType.SEMICOLON, 14),
+        new SourceLocation(SourceType.EOF, 15)
       ]
     );
    });
 
-  it('identifies identifiers with keyword names after dot access', () => { 
+  it('identifies identifiers with keyword names after dot access', () => {
     checkLocations(
       stream(`s.else(0)`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(DOT, 1),
-        new SourceLocation(IDENTIFIER, 2),
-        new SourceLocation(CALL_START, 6),
-        new SourceLocation(NUMBER, 7),
-        new SourceLocation(CALL_END, 8),
-        new SourceLocation(EOF, 9)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.DOT, 1),
+        new SourceLocation(SourceType.IDENTIFIER, 2),
+        new SourceLocation(SourceType.CALL_START, 6),
+        new SourceLocation(SourceType.NUMBER, 7),
+        new SourceLocation(SourceType.CALL_END, 8),
+        new SourceLocation(SourceType.EOF, 9)
       ]
     );
    });
 
-  it('identifies identifiers with keyword names after dot access after a newline', () => { 
+  it('identifies identifiers with keyword names after dot access after a newline', () => {
     checkLocations(
       stream(`s.
 else(0)`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(DOT, 1),
-        new SourceLocation(NEWLINE, 2),
-        new SourceLocation(IDENTIFIER, 3),
-        new SourceLocation(CALL_START, 7),
-        new SourceLocation(NUMBER, 8),
-        new SourceLocation(CALL_END, 9),
-        new SourceLocation(EOF, 10)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.DOT, 1),
+        new SourceLocation(SourceType.NEWLINE, 2),
+        new SourceLocation(SourceType.IDENTIFIER, 3),
+        new SourceLocation(SourceType.CALL_START, 7),
+        new SourceLocation(SourceType.NUMBER, 8),
+        new SourceLocation(SourceType.CALL_END, 9),
+        new SourceLocation(SourceType.EOF, 10)
       ]
     );
    });
 
-  it('identifies identifiers with keyword names after proto access', () => { 
+  it('identifies identifiers with keyword names after proto access', () => {
     checkLocations(
       stream(`s::delete`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(PROTO, 1),
-        new SourceLocation(IDENTIFIER, 3),
-        new SourceLocation(EOF, 9)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.PROTO, 1),
+        new SourceLocation(SourceType.IDENTIFIER, 3),
+        new SourceLocation(SourceType.EOF, 9)
       ]
     );
    });
 
-  it('identifies `null`', () => { 
+  it('identifies `null`', () => {
     checkLocations(
       stream(`null`),
       [
-        new SourceLocation(NULL, 0),
-        new SourceLocation(EOF, 4)
+        new SourceLocation(SourceType.NULL, 0),
+        new SourceLocation(SourceType.EOF, 4)
       ]
     );
    });
 
-  it('identifies `undefined`', () => { 
+  it('identifies `undefined`', () => {
     checkLocations(
       stream(`undefined`),
       [
-        new SourceLocation(UNDEFINED, 0),
-        new SourceLocation(EOF, 9)
+        new SourceLocation(SourceType.UNDEFINED, 0),
+        new SourceLocation(SourceType.EOF, 9)
       ]
     );
    });
 
-  it('identifies `this`', () => { 
+  it('identifies `this`', () => {
     checkLocations(
       stream(`this`),
       [
-        new SourceLocation(THIS, 0),
-        new SourceLocation(EOF, 4)
+        new SourceLocation(SourceType.THIS, 0),
+        new SourceLocation(SourceType.EOF, 4)
       ]
     );
    });
 
-  it('identifies `super`', () => { 
+  it('identifies `super`', () => {
     checkLocations(
       stream(`super`),
       [
-        new SourceLocation(SUPER, 0),
-        new SourceLocation(EOF, 5)
+        new SourceLocation(SourceType.SUPER, 0),
+        new SourceLocation(SourceType.EOF, 5)
       ]
     );
    });
 
-  it('identifies `delete`', () => { 
+  it('identifies `delete`', () => {
     checkLocations(
       stream(`delete a.b`),
       [
-        new SourceLocation(DELETE, 0),
-        new SourceLocation(SPACE, 6),
-        new SourceLocation(IDENTIFIER, 7),
-        new SourceLocation(DOT, 8),
-        new SourceLocation(IDENTIFIER, 9),
-        new SourceLocation(EOF, 10)
+        new SourceLocation(SourceType.DELETE, 0),
+        new SourceLocation(SourceType.SPACE, 6),
+        new SourceLocation(SourceType.IDENTIFIER, 7),
+        new SourceLocation(SourceType.DOT, 8),
+        new SourceLocation(SourceType.IDENTIFIER, 9),
+        new SourceLocation(SourceType.EOF, 10)
       ]
     );
    });
 
-  it('identifies booleans', () => { 
+  it('identifies booleans', () => {
     checkLocations(
       stream(`true;false;yes;no;on;off`),
       [
-        new SourceLocation(BOOL, 0),
-        new SourceLocation(SEMICOLON, 4),
-        new SourceLocation(BOOL, 5),
-        new SourceLocation(SEMICOLON, 10),
-        new SourceLocation(BOOL, 11),
-        new SourceLocation(SEMICOLON, 14),
-        new SourceLocation(BOOL, 15),
-        new SourceLocation(SEMICOLON, 17),
-        new SourceLocation(BOOL, 18),
-        new SourceLocation(SEMICOLON, 20),
-        new SourceLocation(BOOL, 21),
-        new SourceLocation(EOF, 24)
+        new SourceLocation(SourceType.BOOL, 0),
+        new SourceLocation(SourceType.SEMICOLON, 4),
+        new SourceLocation(SourceType.BOOL, 5),
+        new SourceLocation(SourceType.SEMICOLON, 10),
+        new SourceLocation(SourceType.BOOL, 11),
+        new SourceLocation(SourceType.SEMICOLON, 14),
+        new SourceLocation(SourceType.BOOL, 15),
+        new SourceLocation(SourceType.SEMICOLON, 17),
+        new SourceLocation(SourceType.BOOL, 18),
+        new SourceLocation(SourceType.SEMICOLON, 20),
+        new SourceLocation(SourceType.BOOL, 21),
+        new SourceLocation(SourceType.EOF, 24)
       ]
     );
    });
 
-  it('identifies existence operators', () => { 
+  it('identifies existence operators', () => {
     checkLocations(
       stream(`a?.b`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(EXISTENCE, 1),
-        new SourceLocation(DOT, 2),
-        new SourceLocation(IDENTIFIER, 3),
-        new SourceLocation(EOF, 4)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.EXISTENCE, 1),
+        new SourceLocation(SourceType.DOT, 2),
+        new SourceLocation(SourceType.IDENTIFIER, 3),
+        new SourceLocation(SourceType.EOF, 4)
       ]
     );
    });
 
-  it('identifies proto operators', () => { 
+  it('identifies proto operators', () => {
     checkLocations(
       stream(`a::b`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(PROTO, 1),
-        new SourceLocation(IDENTIFIER, 3),
-        new SourceLocation(EOF, 4)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.PROTO, 1),
+        new SourceLocation(SourceType.IDENTIFIER, 3),
+        new SourceLocation(SourceType.EOF, 4)
       ]
     );
    });
 
-  it('identifies inclusive ranges', () => { 
+  it('identifies inclusive ranges', () => {
     checkLocations(
       stream(`a..b`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(RANGE, 1),
-        new SourceLocation(IDENTIFIER, 3),
-        new SourceLocation(EOF, 4)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.RANGE, 1),
+        new SourceLocation(SourceType.IDENTIFIER, 3),
+        new SourceLocation(SourceType.EOF, 4)
       ]
     );
    });
 
-  it('identifies line continuations', () => { 
+  it('identifies line continuations', () => {
     checkLocations(
       stream(`a = \\\n  b`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(SPACE, 1),
-        new SourceLocation(OPERATOR, 2),
-        new SourceLocation(SPACE, 3),
-        new SourceLocation(CONTINUATION, 4),
-        new SourceLocation(NEWLINE, 5),
-        new SourceLocation(SPACE, 6),
-        new SourceLocation(IDENTIFIER, 8),
-        new SourceLocation(EOF, 9)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.SPACE, 1),
+        new SourceLocation(SourceType.OPERATOR, 2),
+        new SourceLocation(SourceType.SPACE, 3),
+        new SourceLocation(SourceType.CONTINUATION, 4),
+        new SourceLocation(SourceType.NEWLINE, 5),
+        new SourceLocation(SourceType.SPACE, 6),
+        new SourceLocation(SourceType.IDENTIFIER, 8),
+        new SourceLocation(SourceType.EOF, 9)
       ]
     );
    });
 
-  it('identifies floor division', () => { 
+  it('identifies floor division', () => {
     checkLocations(
       stream(`7 // 3`),
       [
-        new SourceLocation(NUMBER, 0),
-        new SourceLocation(SPACE, 1),
-        new SourceLocation(OPERATOR, 2),
-        new SourceLocation(SPACE, 4),
-        new SourceLocation(NUMBER, 5),
-        new SourceLocation(EOF, 6)
+        new SourceLocation(SourceType.NUMBER, 0),
+        new SourceLocation(SourceType.SPACE, 1),
+        new SourceLocation(SourceType.OPERATOR, 2),
+        new SourceLocation(SourceType.SPACE, 4),
+        new SourceLocation(SourceType.NUMBER, 5),
+        new SourceLocation(SourceType.EOF, 6)
       ]
     );
    });
 
-  it('identifies compound assignment', () => { 
+  it('identifies compound assignment', () => {
     checkLocations(
       stream(`a ?= 3`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(SPACE, 1),
-        new SourceLocation(OPERATOR, 2),
-        new SourceLocation(SPACE, 4),
-        new SourceLocation(NUMBER, 5),
-        new SourceLocation(EOF, 6)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.SPACE, 1),
+        new SourceLocation(SourceType.OPERATOR, 2),
+        new SourceLocation(SourceType.SPACE, 4),
+        new SourceLocation(SourceType.NUMBER, 5),
+        new SourceLocation(SourceType.EOF, 6)
       ]
     );
    });
 
-  it('identifies compound assignment with word operators', () => { 
+  it('identifies compound assignment with word operators', () => {
     checkLocations(
       stream(`a or= 3`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(SPACE, 1),
-        new SourceLocation(OPERATOR, 2),
-        new SourceLocation(SPACE, 5),
-        new SourceLocation(NUMBER, 6),
-        new SourceLocation(EOF, 7)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.SPACE, 1),
+        new SourceLocation(SourceType.OPERATOR, 2),
+        new SourceLocation(SourceType.SPACE, 5),
+        new SourceLocation(SourceType.NUMBER, 6),
+        new SourceLocation(SourceType.EOF, 7)
       ]
     );
    });
 
-  it('identifies keyword operators', () => { 
+  it('identifies keyword operators', () => {
     checkLocations(
       stream(`a and b is c or d`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(SPACE, 1),
-        new SourceLocation(OPERATOR, 2),
-        new SourceLocation(SPACE, 5),
-        new SourceLocation(IDENTIFIER, 6),
-        new SourceLocation(SPACE, 7),
-        new SourceLocation(OPERATOR, 8),
-        new SourceLocation(SPACE, 10),
-        new SourceLocation(IDENTIFIER, 11),
-        new SourceLocation(SPACE, 12),
-        new SourceLocation(OPERATOR, 13),
-        new SourceLocation(SPACE, 15),
-        new SourceLocation(IDENTIFIER, 16),
-        new SourceLocation(EOF, 17)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.SPACE, 1),
+        new SourceLocation(SourceType.OPERATOR, 2),
+        new SourceLocation(SourceType.SPACE, 5),
+        new SourceLocation(SourceType.IDENTIFIER, 6),
+        new SourceLocation(SourceType.SPACE, 7),
+        new SourceLocation(SourceType.OPERATOR, 8),
+        new SourceLocation(SourceType.SPACE, 10),
+        new SourceLocation(SourceType.IDENTIFIER, 11),
+        new SourceLocation(SourceType.SPACE, 12),
+        new SourceLocation(SourceType.OPERATOR, 13),
+        new SourceLocation(SourceType.SPACE, 15),
+        new SourceLocation(SourceType.IDENTIFIER, 16),
+        new SourceLocation(SourceType.EOF, 17)
       ]
     );
    });
 
-  it('identifies `in` and `of` as relations', () => { 
+  it('identifies `in` and `of` as relations', () => {
     checkLocations(
       stream(`a in b or c of d`),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(SPACE, 1),
-        new SourceLocation(RELATION, 2),
-        new SourceLocation(SPACE, 4),
-        new SourceLocation(IDENTIFIER, 5),
-        new SourceLocation(SPACE, 6),
-        new SourceLocation(OPERATOR, 7),
-        new SourceLocation(SPACE, 9),
-        new SourceLocation(IDENTIFIER, 10),
-        new SourceLocation(SPACE, 11),
-        new SourceLocation(RELATION, 12),
-        new SourceLocation(SPACE, 14),
-        new SourceLocation(IDENTIFIER, 15),
-        new SourceLocation(EOF, 16)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.SPACE, 1),
+        new SourceLocation(SourceType.RELATION, 2),
+        new SourceLocation(SourceType.SPACE, 4),
+        new SourceLocation(SourceType.IDENTIFIER, 5),
+        new SourceLocation(SourceType.SPACE, 6),
+        new SourceLocation(SourceType.OPERATOR, 7),
+        new SourceLocation(SourceType.SPACE, 9),
+        new SourceLocation(SourceType.IDENTIFIER, 10),
+        new SourceLocation(SourceType.SPACE, 11),
+        new SourceLocation(SourceType.RELATION, 12),
+        new SourceLocation(SourceType.SPACE, 14),
+        new SourceLocation(SourceType.IDENTIFIER, 15),
+        new SourceLocation(SourceType.EOF, 16)
       ]
     );
    });
 
-  it('identifies keywords for `try/catch/finally`', () => { 
+  it('identifies keywords for `try/catch/finally`', () => {
     checkLocations(
       stream('try a catch e then b finally c'),
       [
-        new SourceLocation(TRY, 0),
-        new SourceLocation(SPACE, 3),
-        new SourceLocation(IDENTIFIER, 4),
-        new SourceLocation(SPACE, 5),
-        new SourceLocation(CATCH, 6),
-        new SourceLocation(SPACE, 11),
-        new SourceLocation(IDENTIFIER, 12),
-        new SourceLocation(SPACE, 13),
-        new SourceLocation(THEN, 14),
-        new SourceLocation(SPACE, 18),
-        new SourceLocation(IDENTIFIER, 19),
-        new SourceLocation(SPACE, 20),
-        new SourceLocation(FINALLY, 21),
-        new SourceLocation(SPACE, 28),
-        new SourceLocation(IDENTIFIER, 29),
-        new SourceLocation(EOF, 30)
+        new SourceLocation(SourceType.TRY, 0),
+        new SourceLocation(SourceType.SPACE, 3),
+        new SourceLocation(SourceType.IDENTIFIER, 4),
+        new SourceLocation(SourceType.SPACE, 5),
+        new SourceLocation(SourceType.CATCH, 6),
+        new SourceLocation(SourceType.SPACE, 11),
+        new SourceLocation(SourceType.IDENTIFIER, 12),
+        new SourceLocation(SourceType.SPACE, 13),
+        new SourceLocation(SourceType.THEN, 14),
+        new SourceLocation(SourceType.SPACE, 18),
+        new SourceLocation(SourceType.IDENTIFIER, 19),
+        new SourceLocation(SourceType.SPACE, 20),
+        new SourceLocation(SourceType.FINALLY, 21),
+        new SourceLocation(SourceType.SPACE, 28),
+        new SourceLocation(SourceType.IDENTIFIER, 29),
+        new SourceLocation(SourceType.EOF, 30)
       ]
     );
    });
 
-  it('identifies `do` as a keyword', () => { 
+  it('identifies `do` as a keyword', () => {
     checkLocations(
       stream('do foo'),
       [
-        new SourceLocation(DO, 0),
-        new SourceLocation(SPACE, 2),
-        new SourceLocation(IDENTIFIER, 3),
-        new SourceLocation(EOF, 6)
+        new SourceLocation(SourceType.DO, 0),
+        new SourceLocation(SourceType.SPACE, 2),
+        new SourceLocation(SourceType.IDENTIFIER, 3),
+        new SourceLocation(SourceType.EOF, 6)
       ]
     );
    });
 
-  it('identifies `yield` as a keyword', () => { 
+  it('identifies `yield` as a keyword', () => {
     checkLocations(
       stream('yield foo'),
       [
-        new SourceLocation(YIELD, 0),
-        new SourceLocation(SPACE, 5),
-        new SourceLocation(IDENTIFIER, 6),
-        new SourceLocation(EOF, 9)
+        new SourceLocation(SourceType.YIELD, 0),
+        new SourceLocation(SourceType.SPACE, 5),
+        new SourceLocation(SourceType.IDENTIFIER, 6),
+        new SourceLocation(SourceType.EOF, 9)
       ]
     );
    });
 
-  it('identifies `yield from` as keyword', () => { 
+  it('identifies `yield from` as keyword', () => {
     checkLocations(
       stream('yield  from foo'),
       [
-        new SourceLocation(YIELDFROM, 0),
-        new SourceLocation(SPACE, 11),
-        new SourceLocation(IDENTIFIER, 12),
-        new SourceLocation(EOF, 15)
+        new SourceLocation(SourceType.YIELDFROM, 0),
+        new SourceLocation(SourceType.SPACE, 11),
+        new SourceLocation(SourceType.IDENTIFIER, 12),
+        new SourceLocation(SourceType.EOF, 15)
       ]
     );
    });
 
-  it('identifies `from` as an identifier without yield', () => { 
+  it('identifies `from` as an identifier without yield', () => {
     checkLocations(
       stream('from'),
       [
-        new SourceLocation(IDENTIFIER, 0),
-        new SourceLocation(EOF, 4)
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.EOF, 4)
       ]
     );
    });

--- a/test/utils/PaddingTracker_test.ts
+++ b/test/utils/PaddingTracker_test.ts
@@ -1,17 +1,8 @@
 import { deepEqual, strictEqual, throws } from 'assert';
 
-import {
-  stream,
-  DSTRING_END,
-  DSTRING_START,
-  IDENTIFIER,
-  INTERPOLATION_END,
-  INTERPOLATION_START,
-  STRING_CONTENT,
-  STRING_LINE_SEPARATOR,
-  STRING_PADDING
-} from '../../src/index';
+import { stream } from '../../src/index';
 import SourceLocation from '../../src/SourceLocation';
+import SourceType from '../../src/SourceType';
 import BufferedStream from '../../src/utils/BufferedStream';
 import PaddingTracker from '../../src/utils/PaddingTracker';
 
@@ -19,7 +10,7 @@ describe('PaddingTrackerTest', () => {
   it('exposes the fragments in a string and allows marking padding', () => {
     let source = '"a\nb#{cd}e f"';
     let bufferedStream = new BufferedStream(stream(source));
-    let tracker = new PaddingTracker(source, bufferedStream, DSTRING_END);
+    let tracker = new PaddingTracker(source, bufferedStream, SourceType.DSTRING_END);
     strictEqual(tracker.fragments.length, 2);
     strictEqual(tracker.fragments[0].content, 'a\nb');
     strictEqual(tracker.fragments[1].content, 'e f');
@@ -28,17 +19,17 @@ describe('PaddingTrackerTest', () => {
     deepEqual(
       tracker.computeSourceLocations(),
       [
-        new SourceLocation(DSTRING_START, 0),
-        new SourceLocation(STRING_CONTENT, 1),
-        new SourceLocation(STRING_LINE_SEPARATOR, 2),
-        new SourceLocation(STRING_CONTENT, 3),
-        new SourceLocation(INTERPOLATION_START, 4),
-        new SourceLocation(IDENTIFIER, 6),
-        new SourceLocation(INTERPOLATION_END, 8),
-        new SourceLocation(STRING_CONTENT, 9),
-        new SourceLocation(STRING_PADDING, 10),
-        new SourceLocation(STRING_CONTENT, 11),
-        new SourceLocation(DSTRING_END, 12),
+        new SourceLocation(SourceType.DSTRING_START, 0),
+        new SourceLocation(SourceType.STRING_CONTENT, 1),
+        new SourceLocation(SourceType.STRING_LINE_SEPARATOR, 2),
+        new SourceLocation(SourceType.STRING_CONTENT, 3),
+        new SourceLocation(SourceType.INTERPOLATION_START, 4),
+        new SourceLocation(SourceType.IDENTIFIER, 6),
+        new SourceLocation(SourceType.INTERPOLATION_END, 8),
+        new SourceLocation(SourceType.STRING_CONTENT, 9),
+        new SourceLocation(SourceType.STRING_PADDING, 10),
+        new SourceLocation(SourceType.STRING_CONTENT, 11),
+        new SourceLocation(SourceType.DSTRING_END, 12),
       ]
     );
   });
@@ -46,18 +37,18 @@ describe('PaddingTrackerTest', () => {
   it('allows overlapping padding and merges padding regions', () => {
     let source = '"abcdefg"';
     let bufferedStream = new BufferedStream(stream(source));
-    let tracker = new PaddingTracker(source, bufferedStream, DSTRING_END);
+    let tracker = new PaddingTracker(source, bufferedStream, SourceType.DSTRING_END);
     tracker.fragments[0].markPadding(1, 3);
     tracker.fragments[0].markPadding(2, 4);
     tracker.fragments[0].markPadding(4, 5);
     deepEqual(
       tracker.computeSourceLocations(),
       [
-        new SourceLocation(DSTRING_START, 0),
-        new SourceLocation(STRING_CONTENT, 1),
-        new SourceLocation(STRING_PADDING, 2),
-        new SourceLocation(STRING_CONTENT, 6),
-        new SourceLocation(DSTRING_END, 8),
+        new SourceLocation(SourceType.DSTRING_START, 0),
+        new SourceLocation(SourceType.STRING_CONTENT, 1),
+        new SourceLocation(SourceType.STRING_PADDING, 2),
+        new SourceLocation(SourceType.STRING_CONTENT, 6),
+        new SourceLocation(SourceType.DSTRING_END, 8),
       ]
     );
   });
@@ -65,7 +56,7 @@ describe('PaddingTrackerTest', () => {
   it('does not allow padding and a line separator in the same position', () => {
     let source = '"abcdefg"';
     let bufferedStream = new BufferedStream(stream(source));
-    let tracker = new PaddingTracker(source, bufferedStream, DSTRING_END);
+    let tracker = new PaddingTracker(source, bufferedStream, SourceType.DSTRING_END);
     tracker.fragments[0].markPadding(1, 3);
     tracker.fragments[0].markLineSeparator(2);
     throws(() => tracker.computeSourceLocations(), /Illegal padding state/);

--- a/test/utils/calculateTripleQuotedStringPadding_test.ts
+++ b/test/utils/calculateTripleQuotedStringPadding_test.ts
@@ -1,15 +1,5 @@
 import { deepEqual } from 'assert';
-import {
-  stream,
-  IDENTIFIER,
-  INTERPOLATION_END,
-  INTERPOLATION_START,
-  SPACE,
-  STRING_CONTENT,
-  STRING_PADDING,
-  TDSTRING_END,
-  TDSTRING_START
-} from '../../src/index';
+import { stream, SourceType } from '../../src/index';
 import SourceLocation from '../../src/SourceLocation';
 import BufferedStream from '../../src/utils/BufferedStream';
 import calculateTripleQuotedStringPadding from '../../src/utils/calculateTripleQuotedStringPadding';
@@ -141,13 +131,13 @@ b#{c}
     deepEqual(
       calculateTripleQuotedStringPadding(source, bufferedStream(source)),
       [
-        new SourceLocation(TDSTRING_START, 0),
-        new SourceLocation(STRING_PADDING, 3),
-        new SourceLocation(INTERPOLATION_START, 4),
-        new SourceLocation(IDENTIFIER, 6),
-        new SourceLocation(INTERPOLATION_END, 7),
-        new SourceLocation(STRING_PADDING, 8),
-        new SourceLocation(TDSTRING_END, 9)
+        new SourceLocation(SourceType.TDSTRING_START, 0),
+        new SourceLocation(SourceType.STRING_PADDING, 3),
+        new SourceLocation(SourceType.INTERPOLATION_START, 4),
+        new SourceLocation(SourceType.IDENTIFIER, 6),
+        new SourceLocation(SourceType.INTERPOLATION_END, 7),
+        new SourceLocation(SourceType.STRING_PADDING, 8),
+        new SourceLocation(SourceType.TDSTRING_END, 9)
       ]
     );
   });
@@ -157,17 +147,17 @@ b#{c}
     deepEqual(
       calculateTripleQuotedStringPadding(source, bufferedStream(source)),
       [
-        new SourceLocation(TDSTRING_START, 0),
-        new SourceLocation(STRING_CONTENT, 3),
-        new SourceLocation(INTERPOLATION_START, 3),
-        new SourceLocation(IDENTIFIER, 5),
-        new SourceLocation(INTERPOLATION_END, 6),
-        new SourceLocation(STRING_CONTENT, 7),
-        new SourceLocation(INTERPOLATION_START, 7),
-        new SourceLocation(IDENTIFIER, 9),
-        new SourceLocation(INTERPOLATION_END, 10),
-        new SourceLocation(STRING_CONTENT, 11),
-        new SourceLocation(TDSTRING_END, 11)
+        new SourceLocation(SourceType.TDSTRING_START, 0),
+        new SourceLocation(SourceType.STRING_CONTENT, 3),
+        new SourceLocation(SourceType.INTERPOLATION_START, 3),
+        new SourceLocation(SourceType.IDENTIFIER, 5),
+        new SourceLocation(SourceType.INTERPOLATION_END, 6),
+        new SourceLocation(SourceType.STRING_CONTENT, 7),
+        new SourceLocation(SourceType.INTERPOLATION_START, 7),
+        new SourceLocation(SourceType.IDENTIFIER, 9),
+        new SourceLocation(SourceType.INTERPOLATION_END, 10),
+        new SourceLocation(SourceType.STRING_CONTENT, 11),
+        new SourceLocation(SourceType.TDSTRING_END, 11)
       ]
     );
   });
@@ -178,14 +168,14 @@ b#{c}
     deepEqual(
       calculateTripleQuotedStringPadding(source, stream),
       [
-        new SourceLocation(TDSTRING_START, 0),
-        new SourceLocation(STRING_CONTENT, 3),
-        new SourceLocation(TDSTRING_END, 6)
+        new SourceLocation(SourceType.TDSTRING_START, 0),
+        new SourceLocation(SourceType.STRING_CONTENT, 3),
+        new SourceLocation(SourceType.TDSTRING_END, 6)
       ]
     );
     deepEqual(
       stream.peek(),
-      new SourceLocation(SPACE, 9)
+      new SourceLocation(SourceType.SPACE, 9)
     );
   });
 });

--- a/test/utils/verifyStringMatchesCoffeeScript.ts
+++ b/test/utils/verifyStringMatchesCoffeeScript.ts
@@ -1,12 +1,8 @@
 import { deepEqual } from 'assert';
 import * as CoffeeScript from 'decaffeinate-coffeescript';
 
-import lex, {
-  HEREGEXP_START,
-  INTERPOLATION_START,
-  STRING_CONTENT,
-  STRING_LINE_SEPARATOR
-} from '../../src/index';
+import lex  from '../../src/index';
+import SourceType from '../../src/SourceType';
 
 /**
  * Given code containing a string, herestring, or heregex, verify that the
@@ -39,18 +35,18 @@ function getCoffeeLexQuasis(code: string): Array<string> {
   let tokens = lex(code);
   let quasis = [''];
   tokens.forEach(token => {
-    if (token.type === STRING_CONTENT) {
+    if (token.type === SourceType.STRING_CONTENT) {
       quasis[quasis.length - 1] += code.slice(token.start, token.end);
-    } else if (token.type === STRING_LINE_SEPARATOR) {
+    } else if (token.type === SourceType.STRING_LINE_SEPARATOR) {
       quasis[quasis.length - 1] += ' ';
-    } else if (token.type === INTERPOLATION_START) {
+    } else if (token.type === SourceType.INTERPOLATION_START) {
       quasis.push('');
     }
   });
   // As a special case, if this is a heregexp, escaping rules are different, so
   // convert backslash to double backslash. Code using coffee-lex is responsible
   // for adding these escape characters.
-  if (tokens.toArray()[0].type === HEREGEXP_START) {
+  if (tokens.toArray()[0].type === SourceType.HEREGEXP_START) {
     quasis = quasis.map(str => str.replace(/\\/g, '\\\\'));
   }
   return quasis.filter(quasi => quasi.length > 0);


### PR DESCRIPTION
Because both decaffeinate-parser and decaffeinate depend on coffee-lex, it's possible for their versions to be mismatched such that npm will install multiple copies of coffee-lex. This results in problems because the tokens coffee-lex generates have a source type that is an instance of the `SourceType` class, meaning that the same source type in different copies will not be equal to each other, making checking that a token is of a particular type, e.g. `CALL_START`, impossible if the token was created using a different version of coffee-lex than the one used to check the type.

BREAKING CHANGE: To fix this I've changed the `SourceType` class to be an `enum`, so its values will just be explicit numbers that will compare correctly across versions of coffee-lex. Because this changes the API of the "instances" of `SourceType` by removing the `name` property, this is a breaking change. If the `name` of a source type is desired, it can be looked up on the enum type: `SourceType[SourceType.AT] === 'AT'`.