### PR TITLE
fix: restrict access to properties/methods intended to be private/readonly

### DIFF
--- a/src/SourceLocation.ts
+++ b/src/SourceLocation.ts
@@ -4,8 +4,8 @@ import SourceType from './SourceType';
  * Represents a change in source code type at a particular index.
  */
 export default class SourceLocation {
-  type: SourceType;
-  index: number;
+  readonly type: SourceType;
+  readonly index: number;
 
   constructor(type: SourceType, index: number) {
     this.type = type;

--- a/src/SourceToken.ts
+++ b/src/SourceToken.ts
@@ -1,9 +1,9 @@
 import SourceType from './SourceType';
 
 export default class SourceToken {
-  type: SourceType;
-  start: number;
-  end: number;
+  readonly type: SourceType;
+  readonly start: number;
+  readonly end: number;
 
   constructor(type: SourceType, start: number, end: number) {
     if (start > end) {

--- a/src/SourceTokenList.ts
+++ b/src/SourceTokenList.ts
@@ -9,14 +9,14 @@ export type SourceTokenListIndexRange = [SourceTokenListIndex, SourceTokenListIn
  * finding tokens within it.
  */
 export default class SourceTokenList {
-  _tokens: Array<SourceToken>;
-  _indexCache: Array<SourceTokenListIndex>;
-  _indexBySourceIndex: Array<SourceTokenListIndex>;
-  _indexByStartSourceIndex: Array<SourceTokenListIndex>;
-  _indexByEndSourceIndex: Array<SourceTokenListIndex>;
-  length: number;
-  startIndex: SourceTokenListIndex;
-  endIndex: SourceTokenListIndex;
+  private _tokens: Array<SourceToken>;
+  private _indexCache: Array<SourceTokenListIndex>;
+  private _indexBySourceIndex: Array<SourceTokenListIndex>;
+  private _indexByStartSourceIndex: Array<SourceTokenListIndex>;
+  private _indexByEndSourceIndex: Array<SourceTokenListIndex>;
+  readonly length: number;
+  readonly startIndex: SourceTokenListIndex;
+  readonly endIndex: SourceTokenListIndex;
 
   constructor(tokens: Array<SourceToken>) {
     this._validateTokens(tokens);
@@ -74,10 +74,10 @@ export default class SourceTokenList {
    * Get a slice of this token list using the given indexes.
    */
   slice(start: SourceTokenListIndex, end: SourceTokenListIndex): SourceTokenList {
-    if (start._sourceTokenList !== this || end._sourceTokenList !== this) {
+    if (start['_sourceTokenList'] !== this || end['_sourceTokenList'] !== this) {
       throw new Error('cannot slice a list using indexes from another list');
     }
-    return new SourceTokenList(this._tokens.slice(start._index, end._index));
+    return new SourceTokenList(this._tokens.slice(start['_index'], end['_index']));
   }
 
   /**
@@ -88,7 +88,7 @@ export default class SourceTokenList {
    */
   tokenAtIndex(index: SourceTokenListIndex): SourceToken | null {
     this._validateIndex(index);
-    return this._tokens[index._index] || null;
+    return this._tokens[index['_index']] || null;
   }
 
   /**
@@ -335,7 +335,7 @@ export default class SourceTokenList {
   /**
    * @internal
    */
-  _validateTokens(tokens: Array<SourceToken>) {
+  private _validateTokens(tokens: Array<SourceToken>) {
     for (let i = 0; i < tokens.length - 1; i++) {
       if (tokens[i].end > tokens[i + 1].start) {
         throw new Error(
@@ -348,7 +348,7 @@ export default class SourceTokenList {
   /**
    * @internal
    */
-  _validateIndex(index: SourceTokenListIndex | null) {
+  private _validateIndex(index: SourceTokenListIndex | null) {
     if (!index) {
       throw new Error(
         `unexpected 'null' index, perhaps you forgot to check the result of ` +
@@ -361,7 +361,7 @@ export default class SourceTokenList {
         `use list.tokenAtIndex(list.startIndex.advance(${index}))`
       );
     }
-    if (index._sourceTokenList !== this) {
+    if (index['_sourceTokenList'] !== this) {
       throw new Error('cannot get token in one list using an index from another');
     }
   }
@@ -369,7 +369,7 @@ export default class SourceTokenList {
   /**
    * @internal
    */
-  _validateSourceIndex(index: number) {
+  private _validateSourceIndex(index: number) {
     if (typeof index !== 'number') {
       throw new Error(`expected source index to be a number, got: ${index}`);
     }
@@ -378,7 +378,7 @@ export default class SourceTokenList {
   /**
    * @internal
    */
-  _getIndex(index: number): SourceTokenListIndex {
+  private _getIndex(index: number): SourceTokenListIndex {
     let cached = this._indexCache[index];
 
     if (!cached) {

--- a/src/SourceTokenListIndex.ts
+++ b/src/SourceTokenListIndex.ts
@@ -4,8 +4,8 @@ import SourceTokenList from './SourceTokenList';
  * Represents a token at a particular index within a list of tokens.
  */
 export default class SourceTokenListIndex {
-  _sourceTokenList: SourceTokenList;
-  _index: number;
+  private _sourceTokenList: SourceTokenList;
+  private _index: number;
 
   constructor(sourceTokenList: SourceTokenList, index: number) {
     this._sourceTokenList = sourceTokenList;
@@ -21,7 +21,7 @@ export default class SourceTokenListIndex {
     if (newIndex < 0 || this._sourceTokenList.length < newIndex) {
       return null;
     }
-    return this._sourceTokenList._getIndex(newIndex);
+    return this._sourceTokenList['_getIndex'](newIndex);
   }
 
   /**

--- a/src/utils/BufferedStream.ts
+++ b/src/utils/BufferedStream.ts
@@ -2,8 +2,8 @@ import SourceLocation from '../SourceLocation';
 import SourceType from '../SourceType';
 
 export default class BufferedStream {
-  _getNextLocation: () => SourceLocation;
-  pending: Array<SourceLocation> = [];
+  private _getNextLocation: () => SourceLocation;
+  private pending: Array<SourceLocation> = [];
 
   constructor(stream: () => SourceLocation) {
     this._getNextLocation = stream;

--- a/src/utils/PaddingTracker.ts
+++ b/src/utils/PaddingTracker.ts
@@ -24,8 +24,8 @@ import BufferedStream from './BufferedStream';
  * paddingTracker.computeSourceLocations();
  */
 export default class PaddingTracker {
-  fragments: Array<TrackedFragment>;
-  _originalLocations: Array<SourceLocation>;
+  readonly fragments: Array<TrackedFragment>;
+  private _originalLocations: Array<SourceLocation>;
 
   constructor(source: string, stream: BufferedStream, endType: SourceType) {
     this.fragments = [];


### PR DESCRIPTION
Due to TypeScript's lack of an `internal` access modifier, I am using subscripts with strings to access private members from within related classes. Any class member not intended to be reassigned gets `readonly`.