### PR TITLE
fix: lex a number with a leading dot as one token

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -216,6 +216,8 @@ export function stream(source: string, index: number=0): () => SourceLocation {
             setType(SourceType.NEWLINE);
           } else if (consume('...') || consume('..')) {
             setType(SourceType.RANGE);
+          } else if (consume(NUMBER_PATTERN)) {
+            setType(SourceType.NUMBER);
           } else if (consume('.')) {
             setType(SourceType.DOT);
           } else if (consume('"""')) {
@@ -454,8 +456,6 @@ export function stream(source: string, index: number=0): () => SourceLocation {
                   setType(SourceType.IDENTIFIER);
               }
             }
-          } else if (consume(NUMBER_PATTERN)) {
-            setType(SourceType.NUMBER);
           } else if (consume('\\')) {
             setType(SourceType.CONTINUATION);
           } else {

--- a/test/test.ts
+++ b/test/test.ts
@@ -740,6 +740,26 @@ describe('streamTest', () => {
         new SourceLocation(SourceType.EOF, 2)
       ]
     );
+  });
+
+  it('identifies floats as numbers', () => {
+    checkLocations(
+      stream(`1.23`),
+      [
+        new SourceLocation(SourceType.NUMBER, 0),
+        new SourceLocation(SourceType.EOF, 4)
+      ]
+    );
+  });
+
+  it('identifies floats with leading dots as numbers', () => {
+    checkLocations(
+      stream(`.23`),
+      [
+        new SourceLocation(SourceType.NUMBER, 0),
+        new SourceLocation(SourceType.EOF, 3)
+      ]
+    );
    });
 
   it('identifies + as an operator', () => {


### PR DESCRIPTION
Previously, this would be lexed as a `DOT` followed by a `NUMBER`. The regular expression we use to match actually does work with numbers with leading dots, but we were consuming `.` by itself with higher precedence. To fix it, we just move the `NUMBER` match up ahead of the `DOT`.