### PR TITLE
fix: properly identify when regex-like code should be division

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@types/mocha": "^2.2.33",
     "@types/node": "^6.0.52",
-    "decaffeinate-coffeescript": "^1.10.0-patch7",
+    "decaffeinate-coffeescript": "^1.10.0-patch10",
     "mocha": "^3.2.0",
     "semantic-release": "^6.3.5",
     "ts-node": "^2.0.0",

--- a/src/SourceType.ts
+++ b/src/SourceType.ts
@@ -73,6 +73,8 @@ enum SourceType {
   IDENTIFIER = 69,
   YIELD = 70,
   YIELDFROM = 71,
+  INCREMENT = 72,
+  DECREMENT = 73,
 }
 
 export default SourceType;

--- a/test/test.ts
+++ b/test/test.ts
@@ -890,7 +890,7 @@ describe('streamTest', () => {
       [
         new SourceLocation(SourceType.IDENTIFIER, 0),
         new SourceLocation(SourceType.OPERATOR, 1),
-        new SourceLocation(SourceType.OPERATOR, 2),
+        new SourceLocation(SourceType.INCREMENT, 2),
         new SourceLocation(SourceType.IDENTIFIER, 4),
         new SourceLocation(SourceType.EOF, 5)
       ]
@@ -1029,6 +1029,54 @@ describe('streamTest', () => {
       ]
     );
    });
+
+  it('identifies regular expressions with flags', () => {
+    checkLocations(
+      stream(`/foo/g.test 'abc'`),
+      [
+        new SourceLocation(SourceType.REGEXP, 0),
+        new SourceLocation(SourceType.DOT, 6),
+        new SourceLocation(SourceType.IDENTIFIER, 7),
+        new SourceLocation(SourceType.SPACE, 11),
+        new SourceLocation(SourceType.SSTRING_START, 12),
+        new SourceLocation(SourceType.STRING_CONTENT, 13),
+        new SourceLocation(SourceType.SSTRING_END, 16),
+        new SourceLocation(SourceType.EOF, 17)
+      ]
+    );
+  });
+
+  it('identifies regex-like division operations after an increment', () => {
+    checkLocations(
+      stream(`a++ /b/g`),
+      [
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.INCREMENT, 1),
+        new SourceLocation(SourceType.SPACE, 3),
+        new SourceLocation(SourceType.OPERATOR, 4),
+        new SourceLocation(SourceType.IDENTIFIER, 5),
+        new SourceLocation(SourceType.OPERATOR, 6),
+        new SourceLocation(SourceType.IDENTIFIER, 7),
+        new SourceLocation(SourceType.EOF, 8)
+      ]
+    );
+  });
+
+  it('identifies regex-like division operations after a decrement', () => {
+    checkLocations(
+      stream(`a-- /b/g`),
+      [
+        new SourceLocation(SourceType.IDENTIFIER, 0),
+        new SourceLocation(SourceType.DECREMENT, 1),
+        new SourceLocation(SourceType.SPACE, 3),
+        new SourceLocation(SourceType.OPERATOR, 4),
+        new SourceLocation(SourceType.IDENTIFIER, 5),
+        new SourceLocation(SourceType.OPERATOR, 6),
+        new SourceLocation(SourceType.IDENTIFIER, 7),
+        new SourceLocation(SourceType.EOF, 8)
+      ]
+    );
+  });
 
   it('identifies simple heregexes', () => {
     checkLocations(


### PR DESCRIPTION
Progress toward https://github.com/decaffeinate/decaffeinate/issues/702

This was already mostly done, but had two issues:
* Since we didn't have token types for increment and decrement, there wasn't a
  way to check if a regex is predeced by increment or decrement. To fix, I split
  those out into their own source types.
* Regexes with flags were having the flags lexed as an identifier. To fix, I
  consume any flags immediately following a regex and include that with the
  token. This fixes the check for a regex immediately followed by another regex.

BREAKING CHANGE: Increment and decrement tokens now have source type `INCREMENT`
and `DECREMENT` rather than `OPERATOR`. Also, regular expression tokens no
longer incorrectly have an identifier token for their flags.