### PR TITLE
fix: always use `IDENTIFIER` for object key tokens

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -337,7 +337,8 @@ export function stream(source: string, index: number=0): () => SourceLocation {
               prevLocationIndex--;
             }
             let prev = locations[prevLocationIndex];
-            if (prev && (prev.type === SourceType.DOT || prev.type === SourceType.PROTO || prev.type === SourceType.AT)) {
+            let nextIsColon = match(/\s*:/);
+            if (nextIsColon || (prev && (prev.type === SourceType.DOT || prev.type === SourceType.PROTO || prev.type === SourceType.AT))) {
               setType(SourceType.IDENTIFIER);
             } else {
               switch (consumed()) {

--- a/test/test.ts
+++ b/test/test.ts
@@ -1283,6 +1283,29 @@ describe('streamTest', () => {
         new SourceLocation(SourceType.EOF, 15)
       ]
     );
+  });
+
+  it('identifies object keys with keyword names as identifiers', () => {
+    checkLocations(
+      stream(`{break:1,continue:2,this :3}`),
+      [
+        new SourceLocation(SourceType.LBRACE, 0),
+        new SourceLocation(SourceType.IDENTIFIER, 1),
+        new SourceLocation(SourceType.COLON, 6),
+        new SourceLocation(SourceType.NUMBER, 7),
+        new SourceLocation(SourceType.COMMA, 8),
+        new SourceLocation(SourceType.IDENTIFIER, 9),
+        new SourceLocation(SourceType.COLON, 17),
+        new SourceLocation(SourceType.NUMBER, 18),
+        new SourceLocation(SourceType.COMMA, 19),
+        new SourceLocation(SourceType.IDENTIFIER, 20),
+        new SourceLocation(SourceType.SPACE, 24),
+        new SourceLocation(SourceType.COLON, 25),
+        new SourceLocation(SourceType.NUMBER, 26),
+        new SourceLocation(SourceType.RBRACE, 27),
+        new SourceLocation(SourceType.EOF, 28)
+      ]
+    );
    });
 
   it('identifies identifiers with keyword names after dot access', () => {


### PR DESCRIPTION
Previously we would use a keyword-specific token type, such as `BREAK` or `CONTINUE`, for tokens in an object property position. This commit ensures that, if the keyword is followed by a colon, it will be treated as an `IDENTIFIER` and not as a keyword token.

Closes decaffeinate/decaffeinate#713