### PR TITLE
fix: treat `new` in the right context as a distinct token

### DIFF
--- a/src/SourceType.ts
+++ b/src/SourceType.ts
@@ -75,6 +75,7 @@ enum SourceType {
   YIELDFROM = 71,
   INCREMENT = 72,
   DECREMENT = 73,
+  NEW = 74,
 }
 
 export default SourceType;

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,6 +167,7 @@ export function stream(source: string, index: number=0): () => SourceLocation {
         case SourceType.RPAREN:
         case SourceType.CALL_START:
         case SourceType.CALL_END:
+        case SourceType.NEW:
         case SourceType.LBRACE:
         case SourceType.RBRACE:
         case SourceType.LBRACKET:
@@ -394,6 +395,10 @@ export function stream(source: string, index: number=0): () => SourceLocation {
 
                 case 'this':
                   setType(SourceType.THIS);
+                  break;
+
+                case 'new':
+                  setType(SourceType.NEW);
                   break;
 
                 case 'super':

--- a/test/test.ts
+++ b/test/test.ts
@@ -247,6 +247,29 @@ describe('lexTest', () => {
     );
   });
 
+  it('identifies `new` as a NEW token', () => {
+    deepEqual(
+      lex('new A').toArray(),
+      [
+        new SourceToken(SourceType.NEW, 0, 3),
+        new SourceToken(SourceType.IDENTIFIER, 4, 5)
+      ]
+    );
+  });
+
+  it('identifies `new` as an IDENTIFIER in a property name', () => {
+    deepEqual(
+      lex('a\n  new: 5').toArray(),
+      [
+        new SourceToken(SourceType.IDENTIFIER, 0, 1),
+        new SourceToken(SourceType.NEWLINE, 1, 2),
+        new SourceToken(SourceType.IDENTIFIER, 4, 7),
+        new SourceToken(SourceType.COLON, 7, 8),
+        new SourceToken(SourceType.NUMBER, 9, 10)
+      ]
+    );
+  });
+
   it('identifies closing interpolations inside objects', () => {
     deepEqual(
       lex(`{ id: "#{a}" }`).toArray(),


### PR DESCRIPTION
BREAKING CHANGE: Previously, `new` was treated as an `IDENTIFIER`. Now, it is treated as its own token, `NEW`, when used in the right context.