### PR TITLE
fix: properly calculate herestring indentation before interpolations

### DIFF
--- a/src/utils/calculateTripleQuotedStringPadding.ts
+++ b/src/utils/calculateTripleQuotedStringPadding.ts
@@ -95,7 +95,9 @@ function getIndentForFragments(fragments: Array<TrackedFragment>): string {
       }
       hasSeenLine = true;
 
-      if (indent.length === 0 || indent === line) {
+      let isFullLine = i < lines.length - 1 || fragment.index === fragments.length - 1;
+      // Ignore zero-indentation lines and whitespace-only lines.
+      if (indent.length === 0 || (isFullLine && indent === line)) {
         continue;
       }
       if (smallestIndent === null || indent.length < smallestIndent.length) {

--- a/test/utils/calculateTripleQuotedStringPadding_test.ts
+++ b/test/utils/calculateTripleQuotedStringPadding_test.ts
@@ -126,6 +126,13 @@ b#{c}
       ['    a\nb']);
   });
 
+  it('keeps leading spaces in a herestring with interpolations', () => {
+    verifyStringMatchesCoffeeScript(`"""
+  #{a}
+"""`,
+      []);
+  });
+
   it('returns an array with empty leading and trailing string content tokens for a string containing only an interpolation', () => {
     let source = `"""\n#{a}\n"""`;
     deepEqual(


### PR DESCRIPTION
Fixes https://github.com/decaffeinate/decaffeinate/issues/927

Our test for "is this a whitespace-only line" didn't quite work, since it
returned true for the end of a fragment that was followed by an interpolation.
Now, we limit that test to cases where the line we have is actually the full
line from the source code, i.e. intermediate lines in fragments and the last
line of the last fragment.