### PR TITLE
fix: remove escaped newlines from triple-quoted strings

### DIFF
--- a/src/utils/calculateNormalStringPadding.ts
+++ b/src/utils/calculateNormalStringPadding.ts
@@ -3,6 +3,7 @@ import PaddingTracker from './PaddingTracker';
 
 import SourceLocation from '../SourceLocation';
 import BufferedStream from './BufferedStream';
+import isNewlineEscaped from "./isNewlineEscaped";
 
 /**
  * Compute the whitespace to remove in a multiline single or double quoted
@@ -73,25 +74,4 @@ export default function calculateNormalStringPadding(source: string, stream: Buf
     }
   }
   return paddingTracker.computeSourceLocations();
-}
-
-/**
- * A newline character is escaped if it's preceded by an odd number of
- * backslashes. Spaces are allowed between the backslashes and the newline.
- */
-function isNewlineEscaped(content: string, newlinePos: number): boolean {
-  let numSeenBackslashes = 0;
-  let prevPos = newlinePos - 1;
-  while (prevPos >= 0) {
-    let char = content[prevPos];
-    if (numSeenBackslashes === 0 && (char === ' ' || char === '\t')) {
-      prevPos--;
-    } else if (char === '\\') {
-      numSeenBackslashes++;
-      prevPos--;
-    } else {
-      break;
-    }
-  }
-  return numSeenBackslashes % 2 === 1;
 }

--- a/src/utils/calculateTripleQuotedStringPadding.ts
+++ b/src/utils/calculateTripleQuotedStringPadding.ts
@@ -1,6 +1,7 @@
 import SourceLocation from '../SourceLocation';
 import SourceType from '../SourceType';
 import BufferedStream from './BufferedStream';
+import isNewlineEscaped from './isNewlineEscaped';
 import PaddingTracker from './PaddingTracker';
 import { TrackedFragment } from './PaddingTracker';
 
@@ -63,6 +64,11 @@ export default function calculateTripleQuotedStringPadding(source: string, strea
 
   for (let fragment of paddingTracker.fragments) {
     for (let i = 0; i < fragment.content.length; i++) {
+      if (fragment.content[i] === '\n' && isNewlineEscaped(fragment.content, i)) {
+        let backslashPos = fragment.content.lastIndexOf('\\', i);
+        fragment.markPadding(backslashPos, i + 1);
+      }
+
       let isStartOfLine = i > 0 && fragment.content[i - 1] === '\n';
       let isStartOfString = fragment.index === 0 && i === 0;
       if (isStartOfLine || isStartOfString) {

--- a/src/utils/isNewlineEscaped.ts
+++ b/src/utils/isNewlineEscaped.ts
@@ -1,0 +1,21 @@
+/**
+ * In both normal multiline strings and triple quoted strings, a newline
+ * character is escaped if it's preceded by an odd number of backslashes.
+ * Spaces are allowed between the backslashes and the newline.
+ */
+export default function isNewlineEscaped(content: string, newlinePos: number): boolean {
+  let numSeenBackslashes = 0;
+  let prevPos = newlinePos - 1;
+  while (prevPos >= 0) {
+    let char = content[prevPos];
+    if (numSeenBackslashes === 0 && (char === ' ' || char === '\t')) {
+      prevPos--;
+    } else if (char === '\\') {
+      numSeenBackslashes++;
+      prevPos--;
+    } else {
+      break;
+    }
+  }
+  return numSeenBackslashes % 2 === 1;
+}

--- a/test/utils/calculateTripleQuotedStringPadding_test.ts
+++ b/test/utils/calculateTripleQuotedStringPadding_test.ts
@@ -133,6 +133,18 @@ b#{c}
       []);
   });
 
+  it('allows escaping newlines, even with spaces between the backslash and newline', () => {
+    verifyStringMatchesCoffeeScript(`"""a\\  
+b"""`,
+      ['ab']);
+  });
+
+  it('does not escape newlines on an even number of backslashes', () => {
+    verifyStringMatchesCoffeeScript(`"""a\\\\  
+b"""`,
+      ['a\\\\  \nb']);
+  });
+
   it('returns an array with empty leading and trailing string content tokens for a string containing only an interpolation', () => {
     let source = `"""\n#{a}\n"""`;
     deepEqual(


### PR DESCRIPTION
Fixes https://github.com/decaffeinate/decaffeinate/issues/1025

The rules for triple quoted and regular multiline strings are the same (it
seems), so we can mostly just refactor it into a shared function used by both.