### PR TITLE
fix: also remove following whitespace after escaped newlines

### DIFF
--- a/src/utils/calculateTripleQuotedStringPadding.ts
+++ b/src/utils/calculateTripleQuotedStringPadding.ts
@@ -66,7 +66,12 @@ export default function calculateTripleQuotedStringPadding(source: string, strea
     for (let i = 0; i < fragment.content.length; i++) {
       if (fragment.content[i] === '\n' && isNewlineEscaped(fragment.content, i)) {
         let backslashPos = fragment.content.lastIndexOf('\\', i);
-        fragment.markPadding(backslashPos, i + 1);
+        let paddingEnd = i;
+        while (paddingEnd < fragment.content.length &&
+            ' \t\n'.includes(fragment.content[paddingEnd])) {
+          paddingEnd++;
+        }
+        fragment.markPadding(backslashPos, paddingEnd);
       }
 
       let isStartOfLine = i > 0 && fragment.content[i - 1] === '\n';

--- a/test/utils/calculateTripleQuotedStringPadding_test.ts
+++ b/test/utils/calculateTripleQuotedStringPadding_test.ts
@@ -145,6 +145,14 @@ b"""`,
       ['a\\\\  \nb']);
   });
 
+  it('removes all whitespace following an escaped newline', () => {
+    verifyStringMatchesCoffeeScript(`"""a\\  
+     b
+   c
+     d"""`,
+      ['ab\nc\n  d']);
+  });
+
   it('returns an array with empty leading and trailing string content tokens for a string containing only an interpolation', () => {
     let source = `"""\n#{a}\n"""`;
     deepEqual(


### PR DESCRIPTION
In triple-quoted strings, we need to remove all whitespace following an escaped
newline, including any newline characters.