### PR TITLE
fix: don't treat escaped spaces or tabs as whitespace in normal strings

### DIFF
--- a/src/utils/calculateNormalStringPadding.ts
+++ b/src/utils/calculateNormalStringPadding.ts
@@ -39,10 +39,10 @@ export default function calculateNormalStringPadding(source: string, stream: Buf
         pos++;
         // Search forward until the next non-whitespace character. Even skip
         // newlines, so that two or more newlines with only spaces between them
-        // will result in a single line separator. Escaped whitespace characters
+        // will result in a single line separator. Escaped newline characters
         // are also allowed and should be skipped.
         while ((pos < content.length && ' \t\n'.includes(content[pos])) ||
-            (pos < content.length && content[pos] === '\\' && ' \t\n'.includes(content[pos + 1]))) {
+            (content.slice(pos, pos + 2) === '\\\n')) {
           pos++;
         }
         let endIndex = pos;

--- a/test/utils/calculateNormalStringPadding_test.ts
+++ b/test/utils/calculateNormalStringPadding_test.ts
@@ -63,4 +63,11 @@ a
 \\
 "`, ['a']);
   });
+
+  it('does not remove spacing to the right of an escaped space', () => {
+    verifyStringMatchesCoffeeScript(`"
+a
+   \\  b
+"`, ['a   b']);
+  });
 });

--- a/test/utils/verifyStringMatchesCoffeeScript.ts
+++ b/test/utils/verifyStringMatchesCoffeeScript.ts
@@ -48,6 +48,8 @@ function getCoffeeLexQuasis(code: string): Array<string> {
   // for adding these escape characters.
   if (tokens.toArray()[0].type === SourceType.HEREGEXP_START) {
     quasis = quasis.map(str => str.replace(/\\/g, '\\\\'));
+  } else {
+    quasis = quasis.map(normalizeSpaces);
   }
   return quasis.filter(quasi => quasi.length > 0);
 }
@@ -57,7 +59,7 @@ function getCoffeeScriptQuasis(code: string): Array<string> {
   let resultQuasis: Array<string> = [];
   for (let token of tokens) {
     if (token[0] === 'STRING') {
-      let stringForm = token[1].replace(/\t/g, '\\t');
+      let stringForm = normalizeSpaces(token[1].replace(/\t/g, '\\t'));
       if (stringForm[0] === '\'') {
         stringForm = `"${stringForm.slice(1, -1)}"`;
       }
@@ -74,4 +76,21 @@ function getCoffeeScriptQuasis(code: string): Array<string> {
     }
   }
   return resultQuasis.filter(quasi => quasi.length > 0);
+}
+
+function normalizeSpaces(str: string): string {
+  let fixedStr = '';
+  let numBackslashes = 0;
+  for (let i = 0; i < str.length; i++) {
+    if (str[i] === ' ' && numBackslashes % 2 === 1) {
+      fixedStr = fixedStr.slice(0, fixedStr.length - 1);
+    }
+    if (str[i] === '\\') {
+      numBackslashes++;
+    } else {
+      numBackslashes = 0;
+    }
+    fixedStr += str[i];
+  }
+  return fixedStr;
 }


### PR DESCRIPTION
This is a refinement of some previous changes around handling escaped whitespace
characters. It looks like if you escape a space character between two lines, all
following whitespace characters are included.