### PR TITLE
refactor: change lexing to use a context stack instead of multiple stacks

### DIFF
--- a/test/test.ts
+++ b/test/test.ts
@@ -1444,7 +1444,7 @@ else(0)`),
       lex('a = "#{');
       throw new Error('Expected an exception to be thrown.');
     } catch (e) {
-      ok(e.message.indexOf('unexpected EOF while parsing a string') > -1);
+      ok(e.message.indexOf('unexpected EOF while in context INTERPOLATION') > -1);
     }
   });
 
@@ -1453,7 +1453,7 @@ else(0)`),
       lex('a = """#{');
       throw new Error('Expected an exception to be thrown.');
     } catch (e) {
-      ok(e.message.indexOf('unexpected EOF while parsing a string') > -1);
+      ok(e.message.indexOf('unexpected EOF while in context INTERPOLATION') > -1);
     }
   });
 });


### PR DESCRIPTION
This is prep work for supporting CSX in the lexer. We may interleave between
string interpolations, tags, and CSX children, so we need a more robust way to
describe our state.