### PR TITLE
fix: skip CSX parsing when immediately following an rbracket

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -832,7 +832,7 @@ export function stream(source: string, index: number = 0, options: Options = DEF
     if (
       contextType !== ContextType.CSX_BODY &&
       contextType !== ContextType.CSX_OPEN_TAG &&
-      [SourceType.IDENTIFIER, SourceType.RPAREN, SourceType.RBRACE, SourceType.NUMBER].includes(location.type)
+      [SourceType.IDENTIFIER, SourceType.RPAREN, SourceType.RBRACKET, SourceType.NUMBER].includes(location.type)
     ) {
       return false;
     }

--- a/test/test.ts
+++ b/test/test.ts
@@ -1598,6 +1598,18 @@ else(0)`),
     ]);
   });
 
+  it('handles non-CSX after a close-bracket', () => {
+    checkLocations(stream('a[b]<c'), [
+      new SourceLocation(SourceType.IDENTIFIER, 0),
+      new SourceLocation(SourceType.LBRACKET, 1),
+      new SourceLocation(SourceType.IDENTIFIER, 2),
+      new SourceLocation(SourceType.RBRACKET, 3),
+      new SourceLocation(SourceType.OPERATOR, 4),
+      new SourceLocation(SourceType.IDENTIFIER, 5),
+      new SourceLocation(SourceType.EOF, 6)
+    ]);
+  });
+
   it('does not ignore heregex comments when in CS1 mode', () => {
     checkLocations(stream('r = ///\na # #{b}c\n///'), [
       new SourceLocation(SourceType.IDENTIFIER, 0),


### PR DESCRIPTION
I mixed up my brackets and braces when reading the CoffeeScript code and
accidentally ignored after braces.