### PR TITLE
test(ci): update node versions to test with

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ cache:
   directories:
     - node_modules
 node_js:
+  - '11'
   - '10'
-  - '9'
   - '8'
   - '6'
 before_install:


### PR DESCRIPTION
Test in the latest (v11) and all currently supported LTS versions. Node v6 is supported until April 2019, so we can remove it after that.