### PR TITLE
refactor: remove unneeded conditional

### DIFF
--- a/src/SourceTokenList.ts
+++ b/src/SourceTokenList.ts
@@ -368,7 +368,7 @@ export default class SourceTokenList {
         break;
       } else if (predicate(token)) {
         return i;
-      } else if (i) {
+      } else {
         i = i.previous();
       }
     } while (i && i !== end);


### PR DESCRIPTION

This was flagged by LGTM: https://lgtm.com/projects/g/decaffeinate/coffee-lex/snapshot/8c2297bca449499550201946a4f15c7dffd547f0/files/src/SourceTokenList.ts?sort=name&dir=ASC&mode=heatmap#x67e7ccb72f204d67:1

I believe this conditional was present because previous versions of TypeScript were not smart enough to infer that `i` would never be `null` at that position. At some point, TS got smart enough and we can remove the conditional.