### PR TITLE
test(ci): update node versions to test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,6 @@ aliases:
 
 version: 2
 jobs:
-  node-v8-latest:
-    docker:
-      - image: circleci/node:8
-    <<: *unit_test
   node-v10-latest:
     docker:
       - image: circleci/node:10
@@ -48,6 +44,10 @@ jobs:
   node-v12-latest:
     docker:
       - image: circleci/node:12
+    <<: *unit_test
+  node-v13-latest:
+    docker:
+      - image: circleci/node:13
     <<: *unit_test
   deploy:
     docker:
@@ -65,16 +65,16 @@ workflows:
   version: 2
   test-deploy:
     jobs:
-      - node-v8-latest
       - node-v10-latest
       - node-v11-latest
       - node-v12-latest
+      - node-v13-latest
       - deploy:
           requires:
-            - node-v8-latest
             - node-v10-latest
             - node-v11-latest
             - node-v12-latest
+            - node-v13-latest
           filters:
             branches:
               only: master


### PR DESCRIPTION
Node v8.x is about to be EOL’d, and Node v13.x is now available. This drops the one and adds the other.