### PR TITLE
build(dev-deps): remove unnecessary `git add` from `lint-staged` config

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,10 @@
   },
   "lint-staged": {
     "*.{ts,md,json}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ],
     "package.json": [
-      "sort-package-json",
-      "git add"
+      "sort-package-json"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
This is now automatic, and adding it to the config logs a warning:

```
⚠ Some of your tasks use `git add` command. Please remove it from the config since all modifications made by tasks will be automatically added to the git commit index.
```