### PR TITLE
ci(release): run in the right environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   release:
     name: Release
+    environment: Release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Otherwise we don't have access to the `NPM_TOKEN` secret.