### PR TITLE
Fix dist imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,31 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
+    },
+    "./dist/SourceLocation": {
+      "types": "./dist/SourceLocation.d.ts",
+      "import": "./dist/SourceLocation.mjs",
+      "require": "./dist/SourceLocation.js"
+    },
+    "./dist/SourceToken": {
+      "types": "./dist/SourceToken.d.ts",
+      "import": "./dist/SourceToken.mjs",
+      "require": "./dist/SourceToken.js"
+    },
+    "./dist/SourceTokenList": {
+      "types": "./dist/SourceTokenList.d.ts",
+      "import": "./dist/SourceTokenList.mjs",
+      "require": "./dist/SourceTokenList.js"
+    },
+    "./dist/SourceTokenListIndex": {
+      "types": "./dist/SourceTokenListIndex.d.ts",
+      "import": "./dist/SourceTokenListIndex.mjs",
+      "require": "./dist/SourceTokenListIndex.js"
+    },
+    "./dist/SourceType": {
+      "types": "./dist/SourceType.d.ts",
+      "import": "./dist/SourceType.mjs",
+      "require": "./dist/SourceType.js"
     }
   },
   "files": [

--- a/src/SourceLocation.ts
+++ b/src/SourceLocation.ts
@@ -6,3 +6,5 @@ import { SourceType } from './SourceType'
 export class SourceLocation {
   constructor(readonly type: SourceType, readonly index: number) {}
 }
+
+export default SourceLocation

--- a/src/SourceToken.ts
+++ b/src/SourceToken.ts
@@ -13,3 +13,5 @@ export class SourceToken {
     }
   }
 }
+
+export default SourceToken

--- a/src/SourceTokenList.ts
+++ b/src/SourceTokenList.ts
@@ -466,3 +466,5 @@ export class SourceTokenList {
     return this._tokens.slice()
   }
 }
+
+export default SourceTokenList

--- a/src/SourceTokenListIndex.ts
+++ b/src/SourceTokenListIndex.ts
@@ -72,3 +72,5 @@ export class SourceTokenListIndex {
     return other._index - this._index
   }
 }
+
+export default SourceTokenListIndex

--- a/src/SourceType.ts
+++ b/src/SourceType.ts
@@ -90,3 +90,5 @@ export enum SourceType {
   YIELD = 'YIELD',
   YIELDFROM = 'YIELDFROM',
 }
+
+export default SourceType

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,7 @@
 export * from './lex'
 export { lex as default } from './lex'
+export { SourceLocation } from './SourceLocation'
+export { SourceToken } from './SourceToken'
+export { SourceTokenList } from './SourceTokenList'
+export { SourceTokenListIndex } from './SourceTokenListIndex'
+export { SourceType } from './SourceType'

--- a/src/lex.ts
+++ b/src/lex.ts
@@ -134,8 +134,6 @@ function combinedLocationsForNegatedOperators(
 
 const REGEXP_FLAGS = ['i', 'g', 'm', 'u', 'y']
 
-export { SourceType }
-
 /**
  * Borrowed, with tweaks, from CoffeeScript's lexer.coffee.
  */

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -9,5 +9,50 @@ export default defineConfig([
   {
     entry: ['src/index.ts'],
     format: 'esm',
+  },
+  {
+    entry: ['src/SourceLocation.ts'],
+    dts: true,
+    format: 'cjs',
+  },
+  {
+    entry: ['src/SourceLocation.ts'],
+    format: 'esm',
+  },
+  {
+    entry: ['src/SourceToken.ts'],
+    dts: true,
+    format: 'cjs',
+  },
+  {
+    entry: ['src/SourceToken.ts'],
+    format: 'esm',
+  },
+  {
+    entry: ['src/SourceTokenList.ts'],
+    dts: true,
+    format: 'cjs',
+  },
+  {
+    entry: ['src/SourceTokenList.ts'],
+    format: 'esm',
+  },
+  {
+    entry: ['src/SourceTokenListIndex.ts'],
+    dts: true,
+    format: 'cjs',
+  },
+  {
+    entry: ['src/SourceTokenListIndex.ts'],
+    format: 'esm',
+  },
+  {
+    entry: ['src/SourceType.ts'],
+    dts: true,
+    format: 'cjs',
+  },
+  {
+    entry: ['src/SourceType.ts'],
+    format: 'esm',
   }
 ]);


### PR DESCRIPTION
Fix Issue #634 : [ERR_PACKAGE_PATH_NOT_EXPORTED](https://github.com/decaffeinate/coffee-lex/issues/634)
I had to find a way to restore the generation of `dist/Source**` files with default export to support the way they are imported inside `decaffeinate-parser` and `decaffeinate`, 
but the easiest, cleaniest way would be to only use named exports from the root object coffee-lex : 
Replace : 
```js
import SourceToken from 'coffee-lex/dist/SourceToken';
```
with : 
```js
import { SourceToken } from 'coffee-lex';
```

Anyway... Thxx a lot for decaffeinate, we are all into it !! 🤪 

