### PR TITLE
fix(package): export all the things

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,7 @@
 export * from './lex'
 export { lex as default } from './lex'
+export * from './SourceLocation';
+export * from './SourceToken';
+export * from './SourceTokenList';
+export * from './SourceTokenListIndex';
+export * from './SourceType';

--- a/src/lex.ts
+++ b/src/lex.ts
@@ -134,8 +134,6 @@ function combinedLocationsForNegatedOperators(
 
 const REGEXP_FLAGS = ['i', 'g', 'm', 'u', 'y']
 
-export { SourceType }
-
 /**
  * Borrowed, with tweaks, from CoffeeScript's lexer.coffee.
  */


### PR DESCRIPTION
Both decaffeinate and decaffeinate-parser were reaching into the package by importing e.g. `coffee-lex/dist/SourceToken`. This is no longer allowed because I defined the `exports` object in `package.json`. Additionally, since the `dist` only includes a bundled `index.(m)js`, this wouldn't work anyway.

This commit exports all the things that decaffeinate-parser and decaffeinate need.