### PR TITLE
feat(lex): use `CoffeeLexError` with source index

### DIFF
--- a/src/SourceToken.ts
+++ b/src/SourceToken.ts
@@ -1,4 +1,5 @@
 import { SourceType } from './SourceType'
+import { assert } from './utils/assert'
 
 export class SourceToken {
   constructor(
@@ -6,10 +7,6 @@ export class SourceToken {
     readonly start: number,
     readonly end: number
   ) {
-    if (start > end) {
-      throw new Error(
-        `Token start may not be after end. Got ${type}, ${start}, ${end}`
-      )
-    }
+    assert(start <= end, `Token start may not be after end. Got ${type}, ${start}, ${end}`)
   }
 }

--- a/src/SourceTokenList.ts
+++ b/src/SourceTokenList.ts
@@ -1,6 +1,7 @@
 import { SourceToken } from './SourceToken'
 import { SourceTokenListIndex } from './SourceTokenListIndex'
 import { SourceType } from './SourceType'
+import { assert } from './utils/assert'
 
 export type SourceTokenListIndexRange = [
   SourceTokenListIndex,
@@ -104,12 +105,10 @@ export class SourceTokenList {
     start: SourceTokenListIndex,
     end: SourceTokenListIndex
   ): SourceTokenList {
-    if (
-      start['_sourceTokenList'] !== this ||
-      end['_sourceTokenList'] !== this
-    ) {
-      throw new Error('cannot slice a list using indexes from another list')
-    }
+    assert(
+      start['_sourceTokenList'] !== this || end['_sourceTokenList'] !== this,
+      'cannot slice a list using indexes from another list'
+    )
     return new SourceTokenList(
       this._tokens.slice(start['_index'], end['_index'])
     )
@@ -388,9 +387,7 @@ export class SourceTokenList {
           const result = { done: false, value: this.tokenAtIndex(index) }
           const nextIndex = index.next()
 
-          if (!nextIndex) {
-            throw new Error(`unexpected null index before the end index`)
-          }
+          assert(nextIndex, `unexpected null index before the end index`)
 
           index = nextIndex
           return result
@@ -404,12 +401,11 @@ export class SourceTokenList {
    */
   private _validateTokens(tokens: Array<SourceToken>): void {
     for (let i = 0; i < tokens.length - 1; i++) {
-      if (tokens[i].end > tokens[i + 1].start) {
-        throw new Error(
-          `Tokens not in order. Expected ${JSON.stringify(tokens[i])} before ` +
-            `${JSON.stringify(tokens[i + 1])}`
-        )
-      }
+      assert(
+        tokens[i].end <= tokens[i + 1].start,
+        `Tokens not in order. Expected ${JSON.stringify(tokens[i])} before ` +
+          `${JSON.stringify(tokens[i + 1])}`
+      )
     }
   }
 
@@ -417,32 +413,30 @@ export class SourceTokenList {
    * @internal
    */
   private _validateIndex(index: SourceTokenListIndex | null): void {
-    if (!index) {
-      throw new Error(
-        `unexpected 'null' index, perhaps you forgot to check the result of ` +
-          `'indexOfTokenContainingSourceIndex'?`
-      )
-    }
-    if (typeof index === 'number') {
-      throw new Error(
-        `to get a token at index ${index}, ` +
-          `use list.tokenAtIndex(list.startIndex.advance(${index}))`
-      )
-    }
-    if (index['_sourceTokenList'] !== this) {
-      throw new Error(
-        'cannot get token in one list using an index from another'
-      )
-    }
+    assert(
+      index,
+      `unexpected 'null' index, perhaps you forgot to check the result of ` +
+        `'indexOfTokenContainingSourceIndex'?`
+    )
+    assert(
+      typeof index !== 'number',
+      `to get a token at index ${index}, ` +
+        `use list.tokenAtIndex(list.startIndex.advance(${index}))`
+    )
+    assert(
+      index['_sourceTokenList'] === this,
+      'cannot get token in one list using an index from another'
+    )
   }
 
   /**
    * @internal
    */
   private _validateSourceIndex(index: number): void {
-    if (typeof index !== 'number') {
-      throw new Error(`expected source index to be a number, got: ${index}`)
-    }
+    assert(
+      typeof index === 'number',
+      `expected source index to be a number, got: ${index}`
+    )
   }
 
   /**

--- a/src/SourceTokenListIndex.ts
+++ b/src/SourceTokenListIndex.ts
@@ -1,4 +1,5 @@
 import { SourceTokenList } from './SourceTokenList'
+import { assert } from './utils/assert'
 
 /**
  * Represents a token at a particular index within a list of tokens.
@@ -66,9 +67,10 @@ export class SourceTokenListIndex {
    * earlier).
    */
   distance(other: SourceTokenListIndex): number {
-    if (other._sourceTokenList !== this._sourceTokenList) {
-      throw new Error('cannot compare indexes from different lists')
-    }
+    assert(
+      other._sourceTokenList === this._sourceTokenList,
+      'cannot compare indexes from different lists'
+    )
     return other._index - this._index
   }
 }

--- a/src/__tests__/test.ts
+++ b/src/__tests__/test.ts
@@ -1,7 +1,8 @@
-import lex, { consumeStream, stream, SourceType } from '../index'
+import lex, { consumeStream, SourceType, stream } from '../index'
 import { SourceLocation } from '../SourceLocation'
 import { SourceToken } from '../SourceToken'
 import { SourceTokenList } from '../SourceTokenList'
+import { assert } from '../utils/assert'
 
 function checkLocations(
   stream: () => SourceLocation,
@@ -451,11 +452,11 @@ describe('sourceTokenListTest', () => {
         // No token contains this index, so of course it'll be null.
         return
       }
-      if (
-        list.rangeOfInterpolatedStringTokensContainingTokenIndex(index) !== null
-      ) {
-        throw new Error(`expected no range for source index ${sourceIndex}`)
-      }
+      assert(
+        list.rangeOfInterpolatedStringTokensContainingTokenIndex(index) ===
+          null,
+        `expected no range for source index ${sourceIndex}`
+      )
     }
 
     function assertMatchesAtSourceIndex(sourceIndex: number): void {
@@ -463,21 +464,19 @@ describe('sourceTokenListTest', () => {
       const range =
         index && list.rangeOfInterpolatedStringTokensContainingTokenIndex(index)
 
-      if (!range) {
-        throw new Error(
-          `range should not be null for source index ${sourceIndex}`
-        )
-      }
+      assert(range, `range should not be null for source index ${sourceIndex}`)
 
       const [start, end] = range
 
-      if (list.tokenAtIndex(start) !== expectedStart) {
-        throw new Error(`wrong start token for source index ${sourceIndex}`)
-      }
+      assert(
+        list.tokenAtIndex(start) === expectedStart,
+        `wrong start token for source index ${sourceIndex}`
+      )
 
-      if (list.tokenAtIndex(end) !== expectedEnd) {
-        throw new Error(`wrong end token for source index ${sourceIndex}`)
-      }
+      assert(
+        list.tokenAtIndex(end) === expectedEnd,
+        `wrong end token for source index ${sourceIndex}`
+      )
     }
 
     assertNullAtSourceIndex(0) // a
@@ -512,9 +511,7 @@ describe('sourceTokenListTest', () => {
     const interpolationStartToken =
       interpolationStart && list.tokenAtIndex(interpolationStart)
 
-    if (!interpolationStart || !interpolationStartToken) {
-      throw new Error(`unable to find interpolation start token`)
-    }
+    assert(interpolationStartToken, `unable to find interpolation start token`)
 
     expect(interpolationStartToken).toHaveSourceType(
       SourceType.INTERPOLATION_START
@@ -551,9 +548,7 @@ describe('sourceTokenListTest', () => {
         interpolationStart
       )
 
-    if (!range) {
-      throw new Error(`unable to determine range of interpolation start`)
-    }
+    assert(range, `unable to determine range of interpolation start`)
 
     expect(range[0]).toBe(list.startIndex)
     expect(range[1]).toBe(list.endIndex)
@@ -580,9 +575,7 @@ describe('sourceTokenListTest', () => {
         interpolationStart
       )
 
-    if (!range) {
-      throw new Error(`unable to determine range of interpolation start`)
-    }
+    assert(range, `unable to determine range of interpolation start`)
 
     expect(range[0]).toBe(list.startIndex)
     expect(range[1]).toBe(list.endIndex)

--- a/src/__tests__/utils/calculateTripleQuotedStringPadding_test.ts
+++ b/src/__tests__/utils/calculateTripleQuotedStringPadding_test.ts
@@ -1,4 +1,4 @@
-import { stream, SourceType } from '../../index'
+import { SourceType, stream } from '../../index'
 import { SourceLocation } from '../../SourceLocation'
 import { BufferedStream } from '../../utils/BufferedStream'
 import { calculateTripleQuotedStringPadding } from '../../utils/calculateTripleQuotedStringPadding'

--- a/src/__tests__/utils/setupTests.ts
+++ b/src/__tests__/utils/setupTests.ts
@@ -1,8 +1,8 @@
 import { inspect } from 'util'
+import lex from '../..'
 import { SourceLocation } from '../../SourceLocation'
 import { SourceToken } from '../../SourceToken'
 import { SourceType } from '../../SourceType'
-import lex from '../..'
 
 declare global {
   // eslint-disable-next-line no-redeclare, @typescript-eslint/no-namespace

--- a/src/__tests__/utils/verifyStringMatchesCoffeeScript.ts
+++ b/src/__tests__/utils/verifyStringMatchesCoffeeScript.ts
@@ -1,6 +1,4 @@
-import { deepEqual } from 'assert'
 import * as CoffeeScript from 'decaffeinate-coffeescript'
-
 import lex from '../../index'
 import { SourceType } from '../../SourceType'
 
@@ -22,16 +20,8 @@ export function verifyStringMatchesCoffeeScript(
 ): void {
   const coffeeLexResult = getCoffeeLexQuasis(code)
   const coffeeScriptResult = getCoffeeScriptQuasis(code)
-  deepEqual(
-    coffeeLexResult,
-    coffeeScriptResult,
-    'coffee-lex output and CoffeeScript output disagreed.'
-  )
-  deepEqual(
-    coffeeLexResult,
-    expectedQuasis,
-    'coffee-lex output and expected output disagreed.'
-  )
+  expect(coffeeLexResult).toStrictEqual(coffeeScriptResult)
+  expect(coffeeLexResult).toStrictEqual(expectedQuasis)
 }
 
 function getCoffeeLexQuasis(code: string): Array<string> {

--- a/src/utils/PaddingTracker.ts
+++ b/src/utils/PaddingTracker.ts
@@ -1,5 +1,6 @@
 import { SourceLocation } from '../SourceLocation'
 import { SourceType } from '../SourceType'
+import { assert } from './assert'
 import { BufferedStream } from './BufferedStream'
 
 /**
@@ -69,9 +70,10 @@ export class PaddingTracker {
         resultLocations.push(location)
       }
     }
-    if (rangeIndex !== this.fragments.length) {
-      throw new Error('Expected ranges to correspond to original locations.')
-    }
+    assert(
+      rangeIndex === this.fragments.length,
+      'Expected ranges to correspond to original locations.'
+    )
     return resultLocations
   }
 }
@@ -148,15 +150,12 @@ export class TrackedFragment {
           lineSeparatorDepth -= 1
         }
       }
-      if (
-        paddingDepth < 0 ||
-        lineSeparatorDepth < 0 ||
-        (paddingDepth > 0 && lineSeparatorDepth > 0)
-      ) {
-        throw new Error(
-          `Illegal padding state: paddingDepth: ${paddingDepth}, lineSeparatorDepth: ${lineSeparatorDepth}`
-        )
-      }
+      assert(
+        paddingDepth >= 0 &&
+          lineSeparatorDepth >= 0 &&
+          (paddingDepth <= 0 || lineSeparatorDepth <= 0),
+        `Illegal padding state: paddingDepth: ${paddingDepth}, lineSeparatorDepth: ${lineSeparatorDepth}`
+      )
 
       let sourceType
       if (paddingDepth > 0) {

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,0 +1,21 @@
+/**
+ * Asserts `condition` is truthy.
+ */
+export function assert(
+  condition: unknown,
+  message = `expected '${condition}' to be truthy`
+): asserts condition {
+  if (!condition) {
+    throw new Error(message)
+  }
+}
+
+/**
+ * Assert that a value is never used.
+ */
+export function assertNever(
+  value: never,
+  message = `unexpected value: ${value}`
+): never {
+  throw new Error(message)
+}

--- a/src/utils/assertNever.ts
+++ b/src/utils/assertNever.ts
@@ -1,9 +1,0 @@
-/**
- * Assert that a value is never used.
- */
-export function assertNever(
-  value: never,
-  message = `unexpected value: ${value}`
-): never {
-  throw new Error(message)
-}

--- a/src/utils/calculateHeregexpPadding.ts
+++ b/src/utils/calculateHeregexpPadding.ts
@@ -1,8 +1,7 @@
-import { SourceType } from '../SourceType'
-import { PaddingTracker } from './PaddingTracker'
-
 import { SourceLocation } from '../SourceLocation'
+import { SourceType } from '../SourceType'
 import { BufferedStream } from './BufferedStream'
+import { PaddingTracker } from './PaddingTracker'
 
 /**
  * Compute the whitespace to remove in a heregexp. All unescaped whitespace

--- a/src/utils/calculateNormalStringPadding.ts
+++ b/src/utils/calculateNormalStringPadding.ts
@@ -1,9 +1,8 @@
-import { SourceType } from '../SourceType'
-import { PaddingTracker } from './PaddingTracker'
-
 import { SourceLocation } from '../SourceLocation'
+import { SourceType } from '../SourceType'
 import { BufferedStream } from './BufferedStream'
 import { isNewlineEscaped } from './isNewlineEscaped'
+import { PaddingTracker } from './PaddingTracker'
 
 /**
  * Compute the whitespace to remove in a multiline single or double quoted

--- a/src/utils/calculateTripleQuotedStringPadding.ts
+++ b/src/utils/calculateTripleQuotedStringPadding.ts
@@ -2,8 +2,7 @@ import { SourceLocation } from '../SourceLocation'
 import { SourceType } from '../SourceType'
 import { BufferedStream } from './BufferedStream'
 import { isNewlineEscaped } from './isNewlineEscaped'
-import { PaddingTracker } from './PaddingTracker'
-import { TrackedFragment } from './PaddingTracker'
+import { PaddingTracker, TrackedFragment } from './PaddingTracker'
 
 /**
  * Compute the padding (the extra spacing to remove) for the given herestring.


### PR DESCRIPTION
This preserves the source index at which the error happened.