### PR TITLE
fix(tokens): ensure `slice` works again

### DIFF
--- a/src/SourceTokenList.ts
+++ b/src/SourceTokenList.ts
@@ -106,7 +106,7 @@ export class SourceTokenList {
     end: SourceTokenListIndex
   ): SourceTokenList {
     assert(
-      start['_sourceTokenList'] !== this || end['_sourceTokenList'] !== this,
+      start['_sourceTokenList'] === this && end['_sourceTokenList'] === this,
       'cannot slice a list using indexes from another list'
     )
     return new SourceTokenList(

--- a/src/__tests__/test.ts
+++ b/src/__tests__/test.ts
@@ -1738,4 +1738,9 @@ else(0)`),
       'unexpected EOF while in context INTERPOLATION'
     )
   })
+
+  it('can slice', () => {
+    const tokens = lex('a = "abc"');
+    expect(() => tokens.slice(tokens.startIndex, tokens.endIndex)).not.toThrow();
+  });
 })


### PR DESCRIPTION
I messed up the `assert` when I converted it from an `if/throw`.